### PR TITLE
Small fix in parser for returning invalid time unit

### DIFF
--- a/eql/parser.py
+++ b/eql/parser.py
@@ -347,7 +347,7 @@ class EqlWalker(tatsu.walkers.NodeWalker):
             if name.startswith(unit.rstrip('s') or 's'):
                 return ast.TimeRange(datetime.timedelta(seconds=val * interval)), types.literal(types.NUMBER)
 
-        raise self._error(node.unit, "Unknown time unit")
+        raise self._error(node, "Unknown time unit")
 
     def walk__check_parentheses(self, node):
         """Check that parentheses are matching."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -276,6 +276,7 @@ class TestParser(unittest.TestCase):
             'sequence [process where pid == pid]',
             'sequence [process where pid == pid] []',
             'sequence with maxspan=false [process where true] [process where true]',
+            'sequence with maxspan=10g [process where true] [process where true]',
             'sequence with badparam=100 [process where true] [process where true]',
             # check that the same number of BYs are in every subquery
             'sequence [file where true] [process where true] by field1',


### PR DESCRIPTION
## Issues

Error checking for invalid time unit raises an attribute error instead of eql parser error.

```
..\eql\parser.py:1069: in parse_query
    subqueries=subqueries, pipes=pipes)
..\eql\parser.py:990: in _parse
    eql_node = walker.walk(model)
..\eql\parser.py:239: in walk
    output = super(EqlWalker, self).walk(node, *args, **kwargs)
..\venv\lib\site-packages\tatsu\walkers.py:18: in walk
    return walker(node, *args, **kwargs)
..\eql\parser.py:721: in walk__piped_query
    first = self.walk(node.query)
..\eql\parser.py:239: in walk
    output = super(EqlWalker, self).walk(node, *args, **kwargs)
..\venv\lib\site-packages\tatsu\walkers.py:18: in walk
    return walker(node, *args, **kwargs)
..\eql\parser.py:917: in walk__sequence
    params = self.walk(node.params, get_param=self.get_sequence_parameter)
..\eql\parser.py:239: in walk
    output = super(EqlWalker, self).walk(node, *args, **kwargs)
..\venv\lib\site-packages\tatsu\walkers.py:18: in walk
    return walker(node, *args, **kwargs)
..\eql\parser.py:764: in walk__named_params
    key, value = get_param(param, position=position, close=close)
..\eql\parser.py:872: in get_sequence_parameter
    key, (value, value_hint) = self.walk([node.k, node.v])
..\eql\parser.py:239: in walk
    output = super(EqlWalker, self).walk(node, *args, **kwargs)
..\venv\lib\site-packages\tatsu\walkers.py:18: in walk
    return walker(node, *args, **kwargs)
..\eql\parser.py:226: in _walk_default
    return [self.walk(n, *args, **kwargs) for n in node]
..\eql\parser.py:226: in <listcomp>
    return [self.walk(n, *args, **kwargs) for n in node]
..\eql\parser.py:239: in walk
    output = super(EqlWalker, self).walk(node, *args, **kwargs)
..\venv\lib\site-packages\tatsu\walkers.py:18: in walk
    return walker(node, *args, **kwargs)
..\eql\parser.py:350: in walk__time_range
    raise self._error(node.unit, "Unknown time unit")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    @staticmethod
    def _error(node, message, end=False, cls=EqlSemanticError, width=None, **kwargs):
        """Generate."""
>       params = dict(node.ast)
E       AttributeError: 'str' object has no attribute 'ast'

..\eql\parser.py:151: AttributeError
```

## Details
Small fix to return expected node.
