### PR TITLE
Add 'filter' definition

### DIFF
--- a/eql/ast.py
+++ b/eql/ast.py
@@ -9,7 +9,7 @@ from string import Template
 
 from .signatures import SignatureMixin
 from .types import STRING, BOOLEAN, NUMBER, NULL, PRIMITIVES
-from .utils import to_unicode, is_string, is_number, ParserConfig
+from .utils import to_unicode, is_string, is_number
 
 __all__ = (
     # base classes
@@ -53,12 +53,7 @@ __all__ = (
     "EqlAnalytic",
 
     # macros
-    "Definition",
-    "BaseMacro",
-    "CustomMacro",
-    "Macro",
-    "Constant",
-    "PreProcessor",
+
 )
 
 
@@ -218,18 +213,14 @@ class Literal(Expression):
 
     def __and__(self, other):
         """Shortcut ANDing of Static Value nodes together."""
-        if isinstance(other, Literal):
-            return Boolean(self.value and other.value)
-        elif self.value:
+        if self.value:
             return other
         else:
             return Boolean(False)
 
     def __or__(self, other):
         """Shortcut ORing of Static Value nodes together."""
-        if isinstance(other, Literal):
-            return Boolean(self.value or other.value)
-        elif self.value:
+        if self.value:
             return self
         else:
             return other
@@ -1097,181 +1088,6 @@ class EqlAnalytic(EqlNode):
         return {'metadata': self.metadata, 'query': self.query.render()}
 
 
-class Definition(object):
-    """EQL definitions used for pre-processor expansion."""
-
-    __slots__ = 'name',
-
-    def __init__(self, name):
-        """Create a generic definition with a name.
-
-        :param str name: The name of the macro
-        """
-        self.name = name
-        super(Definition, self).__init__()
-
-
-class Constant(Definition, EqlNode):
-    """EQL constant which binds a literal to a name."""
-
-    __slots__ = 'name', 'value',
-    template = Template('const $name = $value')
-
-    def __init__(self, name, value):  # type: (str, Literal) -> None
-        """Create an EQL literal constant."""
-        super(Constant, self).__init__(name)
-        self.value = value
-
-
-class BaseMacro(Definition):
-    """Base macro class."""
-
-    def expand(self, arguments):
-        """Expand a macro with a set of arguments."""
-        raise NotImplementedError
-
-
-class CustomMacro(BaseMacro):
-    """Custom macro class to use Python callbacks to transform trees."""
-
-    def __init__(self, name, callback):
-        """Python macro to allow for more dynamic or sophisticated macros.
-
-        :param str name: The name of the macro.
-        :param (list[EqlNode]) -> EqlNode callback: A callback to expand out the macro.
-        """
-        super(CustomMacro, self).__init__(name)
-        self.callback = callback
-
-    def expand(self, arguments):
-        """Make the callback do the dirty work for expanding the AST."""
-        node = self.callback(arguments)
-        return node.optimize()
-
-    @classmethod
-    def from_name(cls, name):
-        """Decorator to convert a function into a :class:`~CustomMacro` object."""
-        def decorator(f):
-            return CustomMacro(name, f)
-        return decorator
-
-
-class Macro(BaseMacro, EqlNode):
-    """Class for a macro on a node, to allow for client-side expansion."""
-
-    __slots__ = 'name', 'parameters', 'expression'
-    template = Template('macro $name($parameters) $expression')
-    delims = {'parameters': ', '}
-
-    def __init__(self, name, parameters, expression):
-        """Create a named macro that takes a list of arguments and returns a paramaterized expression.
-
-        :param str name: The name of the macro.
-        :param list[str]: The names of the parameters.
-        :param Expression expression: The parameterized expression to return.
-        """
-        BaseMacro.__init__(self, name)
-        EqlNode.__init__(self)
-        self.parameters = parameters
-        self.expression = expression
-
-    def expand(self, arguments):
-        """Expand a node.
-
-        :param list[BaseNode node] arguments: The arguments the macro is called with
-        :param Walker walker: An optional syntax tree walker.
-        :param bool optimize: Return an optimized copy of the AST
-        :rtype: BaseNode
-        """
-        if len(arguments) != len(self.parameters):
-            raise ValueError("Macro {} expected {} arguments but received {}".format(
-                self.name, len(self.parameters), len(arguments)))
-
-        lookup = dict(zip(self.parameters, arguments))
-
-        def _walk_field(node):
-            if node.base in lookup and not node.path:
-                return lookup[node.base].optimize()
-            return node
-
-        walker = RecursiveWalker()
-        walker.register_func(Field, _walk_field)
-        return walker.walk(self.expression).optimize()
-
-    def _render(self):
-        expr = self.expression.render()
-        if '\n' in expr or len(expr) > 40:
-            expr = '\n' + self.indent(expr)
-            return self.template.substitute(name=self.name, parameters=', '.join(self.parameters), expression=expr)
-        return super(Macro, self)._render()
-
-
-class PreProcessor(ParserConfig):
-    """An EQL preprocessor stores definitions and is used for macro expansion and constants."""
-
-    def __init__(self, definitions=None):
-        """Initialize a preprocessor environment that can load definitions."""
-        self.constants = OrderedDict()  # type: dict[str, Constant]
-        self.macros = OrderedDict()  # type: dict[str, BaseMacro|CustomMacro|Maco]
-
-        class PreProcessorWalker(RecursiveWalker):
-            """Custom walker class for this preprocessor."""
-
-            preprocessor = self
-
-            def _walk_field(self, node, *args, **kwargs):
-                if node.base in self.preprocessor.constants and not node.path:
-                        return self.preprocessor.constants[node.base].value
-                return self._walk_base_node(node, *args, **kwargs)
-
-            def _walk_function_call(self, node, *args, **kwargs):
-                if node.name in self.preprocessor.macros:
-                    macro = self.preprocessor.macros[node.name]
-                    arguments = [self.walk(arg, *args, **kwargs) for arg in node.arguments]
-                    return macro.expand(arguments)
-                return self._walk_base_node(node, *args, **kwargs)
-
-        self.walker_cls = PreProcessorWalker
-        ParserConfig.__init__(self, preprocessor=self)
-        self.add_definitions(definitions or [])
-
-    def add_definitions(self, definitions):
-        """Add a list of definitions."""
-        for definition in definitions:
-            self.add_definition(definition)
-
-    def add_definition(self, definition):  # type: (BaseMacro|Constant) -> None
-        """Add a named definition to the preprocessor."""
-        name = definition.name
-        if isinstance(definition, BaseMacro):
-            # The macro may call into other macros so it should be expanded
-            expanded_macro = self.expand(definition)
-            self.macros[name] = expanded_macro
-        elif isinstance(definition, Constant):
-            if name in self.constants:
-                raise KeyError("Constant {} already defined".format(name))
-            self.constants[name] = definition
-
-    def expand(self, root):
-        """Expand the function calls that match registered macros.
-
-        :param EqlNode root: The input node, macro, expression, etc.
-        :param bool optimize: Toggle AST optimizations while expanding
-        :rtype: EqlNode
-        """
-        if not self.constants and not self.macros:
-            return root
-
-        return self.walker_cls().walk(root)
-
-    def copy(self):
-        """Create a shallow copy of a preprocessor."""
-        preprocessor = PreProcessor()
-        preprocessor.constants.update(self.constants)
-        preprocessor.macros.update(self.macros)
-        return preprocessor
-
-
 # circular dependency
-from .walkers import Walker, RecursiveWalker  # noqa: E402
+from .walkers import Walker  # noqa: E402
 from .functions import get_function  # noqa: E402

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -1,8 +1,9 @@
 definitions: definition*
-?definition: macro | constant
+?definition: macro | constant | filter
 
-macro:    "macro" name "(" [name ("," name)*] ")" expr
-constant: "const" name EQUALS literal
+macro:    "macro"  name "(" [name ("," name)*] ")" expr
+constant: "const"  name EQUALS literal
+filter:   "filter" name EQUALS event_query
 
 query_with_definitions: definitions piped_query
 piped_query: base_query [pipes]

--- a/eql/preprocessor.py
+++ b/eql/preprocessor.py
@@ -1,0 +1,210 @@
+"""Helper classes for the EQL preprocessor."""
+from collections import OrderedDict
+from string import Template
+
+from .ast import EqlNode, Field
+from .utils import ParserConfig
+from .walkers import RecursiveWalker
+
+__all__ = (
+    "Definition",
+    "Constant",
+    "BaseMacro",
+    "CustomMacro",
+    "Filter",
+    "Macro",
+    "PreProcessor",
+)
+
+
+class Definition(object):
+    """EQL definitions used for pre-processor expansion."""
+
+    __slots__ = 'name',
+
+    def __init__(self, name):
+        """Create a generic definition with a name.
+
+        :param str name: The name of the macro
+        """
+        self.name = name
+        super(Definition, self).__init__()
+
+
+class Constant(Definition, EqlNode):
+    """EQL constant which binds a literal to a name."""
+
+    __slots__ = 'name', 'value',
+    template = Template('const $name = $value')
+
+    def __init__(self, name, value):  # type: (str, Literal) -> None
+        """Create an EQL literal constant."""
+        super(Constant, self).__init__(name)
+        self.value = value
+
+
+class BaseMacro(Definition):
+    """Base macro class."""
+
+    def expand(self, arguments):
+        """Expand a macro with a set of arguments."""
+        raise NotImplementedError
+
+
+class CustomMacro(BaseMacro):
+    """Custom macro class to use Python callbacks to transform trees."""
+
+    def __init__(self, name, callback):
+        """Python macro to allow for more dynamic or sophisticated macros.
+
+        :param str name: The name of the macro.
+        :param (list[EqlNode]) -> EqlNode callback: A callback to expand out the macro.
+        """
+        super(CustomMacro, self).__init__(name)
+        self.callback = callback
+
+    def expand(self, arguments):
+        """Make the callback do the dirty work for expanding the AST."""
+        node = self.callback(arguments)
+        return node.optimize()
+
+    @classmethod
+    def from_name(cls, name):
+        """Decorator to convert a function into a :class:`~CustomMacro` object."""
+        def decorator(f):
+            return CustomMacro(name, f)
+        return decorator
+
+
+class Filter(Definition):
+    """Class for EQL filter shorthand: `filter x == a where ...`."""
+
+    __slots__ = 'name', 'query'
+
+    def __init__(self, name, query):
+        """Create a named filter, as a short-hand for common queries."""
+        Definition.__init__(self, name)
+        self.query = query
+
+
+class Macro(BaseMacro, EqlNode):
+    """Class for a macro on a node, to allow for client-side expansion."""
+
+    __slots__ = 'name', 'parameters', 'expression'
+    template = Template('macro $name($parameters) $expression')
+    delims = {'parameters': ', '}
+
+    def __init__(self, name, parameters, expression):
+        """Create a named macro that takes a list of arguments and returns a parameterized expression.
+
+        :param str name: The name of the macro.
+        :param list[str]: The names of the parameters.
+        :param Expression expression: The parameterized expression to return.
+        """
+        BaseMacro.__init__(self, name)
+        EqlNode.__init__(self)
+        self.parameters = parameters
+        self.expression = expression
+
+    def expand(self, arguments):
+        """Expand a node.
+
+        :param list[BaseNode node] arguments: The arguments the macro is called with
+        :param Walker walker: An optional syntax tree walker.
+        :param bool optimize: Return an optimized copy of the AST
+        :rtype: BaseNode
+        """
+        if len(arguments) != len(self.parameters):
+            raise ValueError("Macro {} expected {} arguments but received {}".format(
+                self.name, len(self.parameters), len(arguments)))
+
+        lookup = dict(zip(self.parameters, arguments))
+
+        def _walk_field(node):
+            if node.base in lookup and not node.path:
+                return lookup[node.base].optimize()
+            return node
+
+        walker = RecursiveWalker()
+        walker.register_func(Field, _walk_field)
+        return walker.walk(self.expression).optimize()
+
+    def _render(self):
+        expr = self.expression.render()
+        if '\n' in expr or len(expr) > 40:
+            expr = '\n' + self.indent(expr)
+            return self.template.substitute(name=self.name, parameters=', '.join(self.parameters), expression=expr)
+        return super(Macro, self)._render()
+
+
+class PreProcessor(ParserConfig):
+    """An EQL preprocessor stores definitions and is used for macro expansion and constants."""
+
+    def __init__(self, definitions=None):
+        """Initialize a preprocessor environment that can load definitions."""
+        self.constants = OrderedDict()  # type: dict[str, Constant]
+        self.macros = OrderedDict()  # type: dict[str, BaseMacro|CustomMacro|Macro]
+        self.filters = OrderedDict()  # type: dict[str, Filter]
+
+        class PreProcessorWalker(RecursiveWalker):
+            """Custom walker class for this preprocessor."""
+
+            preprocessor = self
+
+            def _walk_field(self, node, *args, **kwargs):
+                if node.base in self.preprocessor.constants and not node.path:
+                        return self.preprocessor.constants[node.base].value
+                return self._walk_base_node(node, *args, **kwargs)
+
+            def _walk_function_call(self, node, *args, **kwargs):
+                if node.name in self.preprocessor.macros:
+                    macro = self.preprocessor.macros[node.name]
+                    arguments = [self.walk(arg, *args, **kwargs) for arg in node.arguments]
+                    return macro.expand(arguments)
+                return self._walk_base_node(node, *args, **kwargs)
+
+        self.walker_cls = PreProcessorWalker
+        ParserConfig.__init__(self, preprocessor=self)
+        self.add_definitions(definitions or [])
+
+    def add_definitions(self, definitions):
+        """Add a list of definitions."""
+        for definition in definitions:
+            self.add_definition(definition)
+
+    def add_definition(self, definition):  # type: (BaseMacro|Constant) -> None
+        """Add a named definition to the preprocessor."""
+        name = definition.name
+
+        if isinstance(definition, BaseMacro):
+            # The macro may call into other macros so it should be expanded
+            expanded_macro = self.expand(definition)
+            self.macros[name] = expanded_macro
+        elif isinstance(definition, Filter):
+            if name in self.filters:
+                raise KeyError("Filter {} already defined".format(name))
+            self.filters[name] = definition
+        elif isinstance(definition, Constant):
+            if name in self.constants:
+                raise KeyError("Constant {} already defined".format(name))
+            self.constants[name] = definition
+
+    def expand(self, root):
+        """Expand the function calls that match registered macros.
+
+        :param EqlNode root: The input node, macro, expression, etc.
+        :param bool optimize: Toggle AST optimizations while expanding
+        :rtype: EqlNode
+        """
+        if not self.constants and not self.macros:
+            return root
+
+        return self.walker_cls().walk(root)
+
+    def copy(self):
+        """Create a shallow copy of a preprocessor."""
+        preprocessor = PreProcessor()
+        preprocessor.constants.update(self.constants)
+        preprocessor.macros.update(self.macros)
+        preprocessor.filters.update(self.filters)
+        return preprocessor

--- a/eql/transpilers.py
+++ b/eql/transpilers.py
@@ -1,5 +1,6 @@
 """Core EQL functionality for query translation."""
-from .ast import PreProcessor, Field
+from .ast import Field
+from .preprocessor import PreProcessor
 from .parser import parse_definitions, ignore_missing_functions
 from .utils import is_string, ParserConfig
 from .walkers import ConfigurableWalker

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,5 @@
-mock>=1.3.0
-pytest~=3.8.2
+mock~=2.0
+pytest~=4.6
 pytest-cov~=2.4
 flake8~=2.5.1
 pep257~=0.7.0

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -6,6 +6,7 @@ from eql.pipes import *  # noqa: F403
 from eql.parser import (
     parse_expression
 )
+from eql.preprocessor import *  # noqa: F403
 from eql.walkers import Walker, RecursiveWalker
 
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -49,17 +49,17 @@ class TestFunctions(unittest.TestCase):
             String("192.168.1.0/24"),
         ]
         position, _, _ = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, 2)
+        self.assertEqual(position, 2)
 
         # test that missing / causes failure
         arguments[2].value = "55.55.55.0"
         position, _, _ = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, 2)
+        self.assertEqual(position, 2)
 
         # test for invalid ip
         arguments[2].value = "55.55.256.0/24"
         position, _, _ = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, 2)
+        self.assertEqual(position, 2)
 
         arguments[2].value = "55.55.55.0/24"
         position, _, _ = CidrMatch.validate(arguments, hints)
@@ -81,14 +81,14 @@ class TestFunctions(unittest.TestCase):
         ]
 
         position, new_arguments, type_hints = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, None)
+        self.assertEqual(position, None)
 
         # check that the original wasn't modified
         self.assertIsNot(arguments[2], new_arguments[2])
 
         # and that the values were set to the base of the subnet
-        self.assertEquals(new_arguments[2].value, "172.169.18.18/31")
-        self.assertEquals(new_arguments[3].value, "192.168.1.0/24")
+        self.assertEqual(new_arguments[2].value, "172.169.18.18/31")
+        self.assertEqual(new_arguments[3].value, "192.168.1.0/24")
 
         # test that /0 is working
         arguments[2] = String("1.2.3.4/0")
@@ -97,7 +97,7 @@ class TestFunctions(unittest.TestCase):
         self.assertIsNot(arguments[2], new_arguments[2])
 
         # and /32
-        self.assertEquals(new_arguments[2].value, "0.0.0.0/0")
+        self.assertEqual(new_arguments[2].value, "0.0.0.0/0")
         arguments[2] = String("12.34.45.56/32")
         position, new_arguments, type_hints = CidrMatch.validate(arguments, hints)
 
@@ -139,7 +139,7 @@ class TestFunctions(unittest.TestCase):
             for num in range(500):
                 should_match = start <= num <= end
                 did_match = regex.match(str(num)) is not None
-                self.assertEquals(should_match, did_match)
+                self.assertEqual(should_match, did_match)
 
     def test_cidr_regex(self):
         """Test that octet regex are correctly matching the range."""
@@ -177,4 +177,4 @@ class TestFunctions(unittest.TestCase):
                 rand_ip = "{:d}.{:d}.{:d}.{:d}".format(*rand_addr)
 
                 rv = regex.match(rand_ip) is not None
-                self.assertEquals(rv, in_subnet)
+                self.assertEqual(rv, in_subnet)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -12,7 +12,8 @@ from eql.parser import (
     extract_query_terms
 )
 from eql.walkers import DepthFirstWalker
-from eql.pipes import *   # noqa: F403
+from eql.pipes import *  # noqa: F403
+from eql.preprocessor import *  # noqa: F403
 
 
 class TestParser(unittest.TestCase):
@@ -54,10 +55,10 @@ class TestParser(unittest.TestCase):
 
     def test_parse_field(self):
         """Test that fields are parsed correctly."""
-        self.assertEquals(parse_field("process_name  "), Field("process_name"))
-        self.assertEquals(parse_field("TRUE  "), Field("TRUE"))
-        self.assertEquals(parse_field("  data[0]"), Field("data", [0]))
-        self.assertEquals(parse_field("data[0].nested.name"), Field("data", [0, "nested", "name"]))
+        self.assertEqual(parse_field("process_name  "), Field("process_name"))
+        self.assertEqual(parse_field("TRUE  "), Field("TRUE"))
+        self.assertEqual(parse_field("  data[0]"), Field("data", [0]))
+        self.assertEqual(parse_field("data[0].nested.name"), Field("data", [0, "nested", "name"]))
 
         self.assertRaises(EqlParseError, parse_field, "  ")
         self.assertRaises(EqlParseError, parse_field, "100.5")
@@ -67,12 +68,12 @@ class TestParser(unittest.TestCase):
 
     def test_parse_literal(self):
         """Test that fields are parsed correctly."""
-        self.assertEquals(parse_literal("true"), Boolean(True))
-        self.assertEquals(parse_literal("null"), Null())
-        self.assertEquals(parse_literal("  100.5  "), Number(100.5))
-        self.assertEquals(parse_literal("true"), Boolean(True))
-        self.assertEquals(parse_literal("'C:\\\\windows\\\\system32\\\\cmd.exe'"),
-                          String("C:\\windows\\system32\\cmd.exe"))
+        self.assertEqual(parse_literal("true"), Boolean(True))
+        self.assertEqual(parse_literal("null"), Null())
+        self.assertEqual(parse_literal("  100.5  "), Number(100.5))
+        self.assertEqual(parse_literal("true"), Boolean(True))
+        self.assertEqual(parse_literal("'C:\\\\windows\\\\system32\\\\cmd.exe'"),
+                         String("C:\\windows\\system32\\cmd.exe"))
 
         self.assertRaises(EqlParseError, parse_field, "and")
         self.assertRaises(EqlParseError, parse_literal, "process_name")
@@ -372,7 +373,7 @@ class TestParser(unittest.TestCase):
         """Test correct parsing and rendering of methods."""
         parse1 = parse_expression("(a and b):concat():length()")
         parse2 = parse_expression("a and b:concat():length()")
-        self.assertNotEquals(parse1, parse2)
+        self.assertNotEqual(parse1, parse2)
 
         class Unmethodize(DepthFirstWalker):
             """Strip out the method metadata, so its rendered directly as a node."""
@@ -384,9 +385,9 @@ class TestParser(unittest.TestCase):
         without_method = Unmethodize().walk(parse1)
         expected = parse_expression("length(concat(a and b))")
 
-        self.assertEquals(parse1, parse_expression("(a and b):concat():length()"))
+        self.assertEqual(parse1, parse_expression("(a and b):concat():length()"))
         self.assertIsNot(parse1, without_method)
-        self.assertEquals(without_method, expected)
+        self.assertEqual(without_method, expected)
 
     def test_term_extraction(self):
         """Test that EQL terms are correctly extracted."""

--- a/tests/test_python_engine.py
+++ b/tests/test_python_engine.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from eql import *  # noqa: F403
 from eql.ast import *  # noqa: F403
 from eql.parser import ignore_missing_functions
+from eql.preprocessor import PreProcessor
 from eql.schema import EVENT_TYPE_GENERIC
 from eql.tests.base import TestEngine
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -102,7 +102,7 @@ class TestSchemaValidation(unittest.TestCase):
         with Schema(self.schema), allow_enum_fields:
             actual = parse_query("process where process_name.bash")
             expected = parse_query("process where process_name == 'bash'")
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
     def test_schema_enum_disabled(self):
         """Test that enum errors are raised when not explicitly enabled."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,7 +82,7 @@ class TestUtils(unittest.TestCase):
             parsed_node = parse_expression(condition_text)
             print(condition_node)
             print(parsed_node)
-            self.assertEquals(condition_node.render(), parsed_node.render(), *args)
+            self.assertEqual(condition_node.render(), parsed_node.render(), *args)
 
         assert_kv_match({"name": "net.exe"},
                         r"name == 'net.exe'",
@@ -146,25 +146,25 @@ class TestUtils(unittest.TestCase):
     def test_output_types(self):
         """Test that output types are correctly returned from eql.utils.get_output_types."""
         query_ast = parse_query("process where true")
-        self.assertEquals(get_output_types(query_ast), ["process"])
+        self.assertEqual(get_output_types(query_ast), ["process"])
 
         query_ast = parse_analytic({"query": "process where descendant of [file where true]"})
-        self.assertEquals(get_output_types(query_ast), ["process"])
+        self.assertEqual(get_output_types(query_ast), ["process"])
 
         query_ast = parse_query("file where true | unique pid | head 1")
-        self.assertEquals(get_output_types(query_ast), ["file"])
+        self.assertEqual(get_output_types(query_ast), ["file"])
 
         query_ast = parse_query("file where true | unique_count file_path")
-        self.assertEquals(get_output_types(query_ast), ["file"])
+        self.assertEqual(get_output_types(query_ast), ["file"])
 
         query_ast = parse_query("any where true | unique_count file_path")
-        self.assertEquals(get_output_types(query_ast), ["any"])
+        self.assertEqual(get_output_types(query_ast), ["any"])
 
         query_ast = parse_query("file where true | count")
-        self.assertEquals(get_output_types(query_ast), ["generic"])
+        self.assertEqual(get_output_types(query_ast), ["generic"])
 
         query_ast = parse_query("file where true | count process_name")
-        self.assertEquals(get_output_types(query_ast), ["generic"])
+        self.assertEqual(get_output_types(query_ast), ["generic"])
 
         query_ast = parse_query("""
         sequence
@@ -175,7 +175,7 @@ class TestUtils(unittest.TestCase):
             [process where true]
             [network where true]
         """)
-        self.assertEquals(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])
+        self.assertEqual(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])
 
         query_ast = parse_query("""
         sequence
@@ -188,7 +188,7 @@ class TestUtils(unittest.TestCase):
         | count event_type
         | head 5
         """)
-        self.assertEquals(get_output_types(query_ast), ["generic"])
+        self.assertEqual(get_output_types(query_ast), ["generic"])
 
         query_ast = parse_query("""
         sequence
@@ -203,4 +203,4 @@ class TestUtils(unittest.TestCase):
         | head 5
         | filter events[4].process_name == 'test.exe'
         """)
-        self.assertEquals(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])
+        self.assertEqual(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues
Resolves #9 

## Details
Adds new syntax for a `filter` definition. This may be problematic and need a new name since it collides with a `filter` pipe. I'm open for suggestions.
```sql
filter process_create = process where subtype.create
```