### PR TITLE
Split out optimizations from the tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
-## Version 0.8.2
+## Version 0.8.4
+_Released 2020-03-18_
+
+### Added
+* `skip_optimizations` toggle to disable optimizations when parsing
+
+### Changed
+* Moved optimization methods to `Optimizer` class.
+
+
+## Version 0.8.3
 _Released 2020-03-11_
 
 ### Fixed
@@ -15,11 +25,13 @@ _Released 2020-01-13_
 ### Fixed
 * Restored missing text from semantic error messages
 
+
 ## Version 0.8.1
 _Released 2020-01-09_
 
 ### Fixed
 * Correctly load definitions/schema with `eql.build.get_engine`
+
 
 ## Version 0.8
 _Released 2019-11-01_
@@ -38,6 +50,7 @@ _Released 2019-11-01_
 ### Fixed
 * Examples for sequences in the Implementation Details page
 * Compatibility for `eql shell` with Python 2.7
+
 
 ## Version 0.7
 _Released 2019-07-24_
@@ -76,11 +89,13 @@ _Released 2019-07-24_
 ### Removed
 * Default EQL schema. Now accepts all input and event types by default
 
+
 ## Version 0.6.3
 _Released 2019-04-17_
 
 ### Added
 * @itsnotapt Made `pid` and `ppid` fields configurable
+
 
 ## Version 0.6.2
 _Released 2018-12-13_
@@ -88,11 +103,13 @@ _Released 2018-12-13_
 ### Fixed
 * Broken implementation of streaming .jsonl files
 
+
 ## Version 0.6.1
 _Released 2019-12-05_
 
 ### Added
 * Support for gzipped files
+
 
 ## Version 0.6
 _Initial Release 2018-11_30_

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -29,6 +29,7 @@ from .loader import (
     save_analytic,
     save_analytics,
 )
+from .optimizer import Optimizer
 from .parser import (
     allow_enum_fields,
     get_preprocessor,
@@ -41,6 +42,7 @@ from .parser import (
     parse_field,
     parse_literal,
     parse_query,
+    skip_optimizations,
     strict_field_schema,
     extract_query_terms,
 )
@@ -66,7 +68,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 __all__ = (
     "__version__",
     "AnalyticOutput",
@@ -83,6 +85,7 @@ __all__ = (
     "EqlTypeMismatchError",
     "Event",
     "NodeMethods",
+    "Optimizer",
     "ParserConfig",
     "PythonEngine",
     "RecursiveWalker",
@@ -121,5 +124,6 @@ __all__ = (
     "save_analytic",
     "save_analytics",
     "save_dump",
+    "skip_optimizations",
     "strict_field_schema",
 )

--- a/eql/optimizer.py
+++ b/eql/optimizer.py
@@ -1,0 +1,143 @@
+"""Optimizer for the EQL syntax tree."""
+from .functions import get_function
+from .utils import is_string
+from .walkers import Walker, DepthFirstWalker
+
+__all__ = (
+    "Optimizer",
+)
+
+
+class Optimizer(DepthFirstWalker):
+    """Class for optimizing AST nodes."""
+
+    def __init__(self, recursive=False):
+        """Class for optimizing AST nodes."""
+        Walker.__init__(self)
+        self.recursive = recursive
+
+    def walk(self, node, *args, **kwargs):
+        """Override the default walk to optionally recurse."""
+        if self.recursive:
+            return DepthFirstWalker.walk(self, node, *args, **kwargs)
+
+        return Walker.walk(self, node, *args, **kwargs)
+
+    @staticmethod
+    def _walk_and(node):
+        terms = []
+        current = node.terms[0]
+        for term in node.terms[1:]:
+            current = current & term
+            if isinstance(current, And):
+                terms.extend(current.terms[:-1])
+                current = current.terms[-1]
+
+        if terms:
+            terms.append(current)
+            return And(terms)
+        return current
+
+    @staticmethod
+    def _walk_comparison(node):
+        if isinstance(node.left, Literal) and isinstance(node.right, Literal):
+            lhs = node.left.value
+            rhs = node.right.value
+
+            # Check that the types match first
+            if not isinstance(node.right, type(node.left)):
+                return Boolean(node.comparator == Comparison.NE)
+
+            if isinstance(node.left, String):
+                lhs = lhs.lower()
+                rhs = rhs.lower()
+
+            return Boolean(node.function(lhs, rhs))
+
+        # assumes calling the same function twice with the same args returns the same result
+        elif node.left == node.right:
+            return Boolean(node.comparator in (Comparison.EQ, Comparison.LE, Comparison.GE))
+
+        return node
+
+    @staticmethod
+    def _walk_function_call(node):  # type: (FunctionCall) -> EqlNode
+        func = get_function(node.name)
+        arguments = [arg.optimize() for arg in node.arguments]
+
+        if func and all(isinstance(arg, Literal) for arg in arguments):
+            try:
+                rv = func.run(*[arg.value for arg in arguments])
+                return Literal.from_python(rv)
+            except NotImplementedError:
+                pass
+
+        return FunctionCall(node.name, arguments, node.as_method)
+
+    @staticmethod
+    def _walk_in_set(node):
+        expression = node.expression
+
+        # move all the literals to the front, preserve their ordering
+        literals = [v for k, v in node.get_literals().items()]
+        dynamic = [v for v in node.container if not isinstance(v, Literal)]
+        container = literals + dynamic
+
+        # check to see if a literal value is in the list of literal values
+        if isinstance(node.expression, Literal):
+            value = node.expression.value
+            if is_string(value):
+                value = value.lower()
+            if value in node.get_literals():
+                return Boolean(True)
+            container = dynamic
+
+        if len(container) == 0:
+            return Boolean(False)
+        elif len(container) == 1:
+            return Comparison(expression, Comparison.EQ, container[0]).optimize()
+        elif expression in container:
+            return Boolean(True)
+
+        return InSet(expression, container)
+
+    @staticmethod
+    def _walk_math_operation(node):
+        left = node.left.optimize()
+        right = node.right.optimize()
+
+        if isinstance(left, Number) and isinstance(right, Number):
+            # don't divide by zero when optimizing, leave that to the target implementation
+            if not (right.value == 0 and node.operator in ("/", "%")):
+                return Number(node.func(left.value, right.value))
+
+        if isinstance(right, MathOperation) and right.left == Number(0):
+            # a +- b parses as a + (0 - b) should become a + -b
+            if node.operator in ("-", "+") and right.operator in ("-", "+"):
+                operator = "-" if (node.operator == "-") ^ (right.operator == "-") else "+"
+                return MathOperation(left, operator, right.right)
+
+        return MathOperation(left, node.operator, right)
+
+    @staticmethod
+    def _walk_not(node):
+        optimized_term = node.term.optimize()
+        return ~ optimized_term
+
+    @staticmethod
+    def _walk_or(node):
+        terms = []
+        current = node.terms[0]
+        for term in node.terms[1:]:
+            current = current | term
+            if isinstance(current, Or):
+                terms.extend(current.terms[:-1])
+                current = current.terms[-1]
+
+        if terms:
+            terms.append(current)
+            return Or(terms)
+        return current
+
+
+from .ast import *  # noqa: E402

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -24,7 +24,7 @@ class TestFunctions(unittest.TestCase):
         for source in sources:
             self.assertTrue(Match.run(source, ".*comment"))
             # \n newlines must match on \n \s etc. but won't match on " "
-            self.assertTrue(Match.run(source, ".*this\sis\s.*comment"))
+            self.assertTrue(Match.run(source, r".*this\sis\s.*comment"))
             self.assertTrue(Match.run(source, "t.+a.+c.+"))
             self.assertFalse(Match.run(source, "MiSsInG"))
 
@@ -49,17 +49,17 @@ class TestFunctions(unittest.TestCase):
             String("192.168.1.0/24"),
         ]
         position, _, _ = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, 2)
+        self.assertEqual(position, 2)
 
         # test that missing / causes failure
         arguments[2].value = "55.55.55.0"
         position, _, _ = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, 2)
+        self.assertEqual(position, 2)
 
         # test for invalid ip
         arguments[2].value = "55.55.256.0/24"
         position, _, _ = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, 2)
+        self.assertEqual(position, 2)
 
         arguments[2].value = "55.55.55.0/24"
         position, _, _ = CidrMatch.validate(arguments, hints)
@@ -81,14 +81,14 @@ class TestFunctions(unittest.TestCase):
         ]
 
         position, new_arguments, type_hints = CidrMatch.validate(arguments, hints)
-        self.assertEquals(position, None)
+        self.assertEqual(position, None)
 
         # check that the original wasn't modified
         self.assertIsNot(arguments[2], new_arguments[2])
 
         # and that the values were set to the base of the subnet
-        self.assertEquals(new_arguments[2].value, "172.169.18.18/31")
-        self.assertEquals(new_arguments[3].value, "192.168.1.0/24")
+        self.assertEqual(new_arguments[2].value, "172.169.18.18/31")
+        self.assertEqual(new_arguments[3].value, "192.168.1.0/24")
 
         # test that /0 is working
         arguments[2] = String("1.2.3.4/0")
@@ -97,7 +97,7 @@ class TestFunctions(unittest.TestCase):
         self.assertIsNot(arguments[2], new_arguments[2])
 
         # and /32
-        self.assertEquals(new_arguments[2].value, "0.0.0.0/0")
+        self.assertEqual(new_arguments[2].value, "0.0.0.0/0")
         arguments[2] = String("12.34.45.56/32")
         position, new_arguments, type_hints = CidrMatch.validate(arguments, hints)
 
@@ -139,7 +139,7 @@ class TestFunctions(unittest.TestCase):
             for num in range(500):
                 should_match = start <= num <= end
                 did_match = regex.match(str(num)) is not None
-                self.assertEquals(should_match, did_match)
+                self.assertEqual(should_match, did_match)
 
     def test_cidr_regex(self):
         """Test that octet regex are correctly matching the range."""
@@ -177,4 +177,4 @@ class TestFunctions(unittest.TestCase):
                 rand_ip = "{:d}.{:d}.{:d}.{:d}".format(*rand_addr)
 
                 rv = regex.match(rand_ip) is not None
-                self.assertEquals(rv, in_subnet)
+                self.assertEqual(rv, in_subnet)

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -2,7 +2,7 @@
 import unittest
 
 from eql.ast import *  # noqa: F403
-from eql.parser import parse_expression
+from eql.parser import parse_expression, skip_optimizations
 
 
 class TestParseOptimizations(unittest.TestCase):
@@ -178,3 +178,9 @@ class TestParseOptimizations(unittest.TestCase):
             ast = parse_expression(expression)
             self.assertIsInstance(ast, Boolean, 'Failed to optimize {}'.format(expression))
             self.assertFalse(ast.value, 'Parser did not evaluate {} as false'.format(expression))
+
+    def test_unoptimized(self):
+        """Test that optimization can be turned off."""
+        with skip_optimizations:
+            self.assertEqual(parse_expression("1 + 2"), MathOperation(Number(1), "+", Number(2)))
+            self.assertEqual(parse_expression("1 + 2"), MathOperation(Number(1), "+", Number(2)))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -54,10 +54,10 @@ class TestParser(unittest.TestCase):
 
     def test_parse_field(self):
         """Test that fields are parsed correctly."""
-        self.assertEquals(parse_field("process_name  "), Field("process_name"))
-        self.assertEquals(parse_field("TRUE  "), Field("TRUE"))
-        self.assertEquals(parse_field("  data[0]"), Field("data", [0]))
-        self.assertEquals(parse_field("data[0].nested.name"), Field("data", [0, "nested", "name"]))
+        self.assertEqual(parse_field("process_name  "), Field("process_name"))
+        self.assertEqual(parse_field("TRUE  "), Field("TRUE"))
+        self.assertEqual(parse_field("  data[0]"), Field("data", [0]))
+        self.assertEqual(parse_field("data[0].nested.name"), Field("data", [0, "nested", "name"]))
 
         self.assertRaises(EqlParseError, parse_field, "  ")
         self.assertRaises(EqlParseError, parse_field, "100.5")
@@ -67,12 +67,12 @@ class TestParser(unittest.TestCase):
 
     def test_parse_literal(self):
         """Test that fields are parsed correctly."""
-        self.assertEquals(parse_literal("true"), Boolean(True))
-        self.assertEquals(parse_literal("null"), Null())
-        self.assertEquals(parse_literal("  100.5  "), Number(100.5))
-        self.assertEquals(parse_literal("true"), Boolean(True))
-        self.assertEquals(parse_literal("'C:\\\\windows\\\\system32\\\\cmd.exe'"),
-                          String("C:\\windows\\system32\\cmd.exe"))
+        self.assertEqual(parse_literal("true"), Boolean(True))
+        self.assertEqual(parse_literal("null"), Null())
+        self.assertEqual(parse_literal("  100.5  "), Number(100.5))
+        self.assertEqual(parse_literal("true"), Boolean(True))
+        self.assertEqual(parse_literal("'C:\\\\windows\\\\system32\\\\cmd.exe'"),
+                         String("C:\\windows\\system32\\cmd.exe"))
 
         self.assertRaises(EqlParseError, parse_field, "and")
         self.assertRaises(EqlParseError, parse_literal, "process_name")
@@ -372,7 +372,7 @@ class TestParser(unittest.TestCase):
         """Test correct parsing and rendering of methods."""
         parse1 = parse_expression("(a and b):concat():length()")
         parse2 = parse_expression("a and b:concat():length()")
-        self.assertNotEquals(parse1, parse2)
+        self.assertNotEqual(parse1, parse2)
 
         class Unmethodize(DepthFirstWalker):
             """Strip out the method metadata, so its rendered directly as a node."""
@@ -384,9 +384,9 @@ class TestParser(unittest.TestCase):
         without_method = Unmethodize().walk(parse1)
         expected = parse_expression("length(concat(a and b))")
 
-        self.assertEquals(parse1, parse_expression("(a and b):concat():length()"))
+        self.assertEqual(parse1, parse_expression("(a and b):concat():length()"))
         self.assertIsNot(parse1, without_method)
-        self.assertEquals(without_method, expected)
+        self.assertEqual(without_method, expected)
 
     def test_term_extraction(self):
         """Test that EQL terms are correctly extracted."""

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -88,7 +88,7 @@ class TestPreProcessor(unittest.TestCase):
             parse_query("process where true | filter CONSTANT()")
 
             # unique requires a dynamic type, but there are no fields in CONSTANT
-            with self.assertRaisesRegexp(EqlTypeMismatchError, "Expected dynamic boolean/number/string"):
+            with self.assertRaisesRegex(EqlTypeMismatchError, "Expected dynamic boolean/number/string"):
                 parse_query("process where true | unique CONSTANT()")
 
     def test_macro_expansion(self):
@@ -163,10 +163,10 @@ class TestPreProcessor(unittest.TestCase):
                 self.assertEqual(actual.render(), expected.render(), error_msg)
 
             query = parse_expression("DESCENDANT_OF_PROC()")
-            self.assertRaisesRegexp(ValueError, "Macro .+ expected \d+ arguments .*", engine.expand, query)
+            self.assertRaisesRegex(ValueError, r"Macro .+ expected \d+ arguments .*", engine.expand, query)
 
             query = parse_expression("DESCENDANT_OF_PROC(1,2,3)")
-            self.assertRaisesRegexp(ValueError, "Macro .+ expected \d+ arguments .*", engine.expand, query)
+            self.assertRaisesRegex(ValueError, r"Macro .+ expected \d+ arguments .*", engine.expand, query)
 
     def test_custom_macro(self):
         """Test python custom macro expansion."""
@@ -190,7 +190,7 @@ class TestPreProcessor(unittest.TestCase):
         with ignore_missing_functions:
             example = parse_query('process where LENGTH("abc", "def")')
 
-        self.assertRaisesRegexp(ValueError, "too many values to unpack", engine.expand, example)
+        self.assertRaisesRegex(ValueError, "too many values to unpack", engine.expand, example)
 
     def test_load_definitions_from_file(self):
         """Test loading definitions from a file."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -102,7 +102,7 @@ class TestSchemaValidation(unittest.TestCase):
         with Schema(self.schema), allow_enum_fields:
             actual = parse_query("process where process_name.bash")
             expected = parse_query("process where process_name == 'bash'")
-            self.assertEquals(actual, expected)
+            self.assertEqual(actual, expected)
 
     def test_schema_enum_disabled(self):
         """Test that enum errors are raised when not explicitly enabled."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -82,7 +82,7 @@ class TestUtils(unittest.TestCase):
             parsed_node = parse_expression(condition_text)
             print(condition_node)
             print(parsed_node)
-            self.assertEquals(condition_node.render(), parsed_node.render(), *args)
+            self.assertEqual(condition_node.render(), parsed_node.render(), *args)
 
         assert_kv_match({"name": "net.exe"},
                         r"name == 'net.exe'",
@@ -146,25 +146,25 @@ class TestUtils(unittest.TestCase):
     def test_output_types(self):
         """Test that output types are correctly returned from eql.utils.get_output_types."""
         query_ast = parse_query("process where true")
-        self.assertEquals(get_output_types(query_ast), ["process"])
+        self.assertEqual(get_output_types(query_ast), ["process"])
 
         query_ast = parse_analytic({"query": "process where descendant of [file where true]"})
-        self.assertEquals(get_output_types(query_ast), ["process"])
+        self.assertEqual(get_output_types(query_ast), ["process"])
 
         query_ast = parse_query("file where true | unique pid | head 1")
-        self.assertEquals(get_output_types(query_ast), ["file"])
+        self.assertEqual(get_output_types(query_ast), ["file"])
 
         query_ast = parse_query("file where true | unique_count file_path")
-        self.assertEquals(get_output_types(query_ast), ["file"])
+        self.assertEqual(get_output_types(query_ast), ["file"])
 
         query_ast = parse_query("any where true | unique_count file_path")
-        self.assertEquals(get_output_types(query_ast), ["any"])
+        self.assertEqual(get_output_types(query_ast), ["any"])
 
         query_ast = parse_query("file where true | count")
-        self.assertEquals(get_output_types(query_ast), ["generic"])
+        self.assertEqual(get_output_types(query_ast), ["generic"])
 
         query_ast = parse_query("file where true | count process_name")
-        self.assertEquals(get_output_types(query_ast), ["generic"])
+        self.assertEqual(get_output_types(query_ast), ["generic"])
 
         query_ast = parse_query("""
         sequence
@@ -175,7 +175,7 @@ class TestUtils(unittest.TestCase):
             [process where true]
             [network where true]
         """)
-        self.assertEquals(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])
+        self.assertEqual(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])
 
         query_ast = parse_query("""
         sequence
@@ -188,7 +188,7 @@ class TestUtils(unittest.TestCase):
         | count event_type
         | head 5
         """)
-        self.assertEquals(get_output_types(query_ast), ["generic"])
+        self.assertEqual(get_output_types(query_ast), ["generic"])
 
         query_ast = parse_query("""
         sequence
@@ -203,4 +203,4 @@ class TestUtils(unittest.TestCase):
         | head 5
         | filter events[4].process_name == 'test.exe'
         """)
-        self.assertEquals(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])
+        self.assertEqual(get_output_types(query_ast), ["registry", "file", "process", "process", "process", "network"])


### PR DESCRIPTION
## Issues
Resolves #11

## Details
* Moves all optimize() methods to an Optimizer class.
* Fixes a minor bug with failed optimizations for sets + comparisons on the same field:
 `A in (a, b, c, ...) or A == z` to `A in (a, b, c, ..., z)`