### PR TITLE
Make missing 'where' raise EqlSyntaxError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.8.6
+_Released 2020-04-06_
+
+### Changed
+* Made missing `where` raise a `EqlSyntaxError` instead of a `EqlSemanticError`
+
 
 ## Version 0.8.5
 _Released 2020-03-18_

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -68,7 +68,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.8.5'
+__version__ = '0.8.6'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -14,7 +14,7 @@ from lark.exceptions import LarkError
 from . import ast
 from . import pipes
 from . import types
-from .errors import EqlParseError, EqlSyntaxError, EqlSemanticError, EqlSchemaError, EqlTypeMismatchError, EqlError
+from .errors import EqlSyntaxError, EqlSemanticError, EqlSchemaError, EqlTypeMismatchError, EqlError
 from .etc import get_etc_file
 from .functions import get_function, list_functions
 from .optimizer import Optimizer
@@ -192,7 +192,7 @@ class LarkToEQL(Interpreter):
         return len(self._pipe_schemas) > 1
 
     def _error(self, node, message, end=False, cls=EqlSemanticError, width=None, **kwargs):
-        # type: (KvTree, str) -> Exception
+        # type: (KvTree, str, bool, type, int, object) -> Exception
         """Generate."""
         params = {}
         for child in node.children:
@@ -820,7 +820,7 @@ class LarkToEQL(Interpreter):
         if node["name"] is None:
             event_type = EVENT_TYPE_ANY
             if not self.implied_any:
-                raise self._error(node, "Missing event type and 'where' condition")
+                raise self._error(node, "Missing event type and 'where' condition", cls=EqlSyntaxError)
         else:
             event_type = self.visit(node["name"])
 
@@ -1154,7 +1154,7 @@ def _parse(text, start=None, preprocessor=None, implied_any=False, implied_base=
     :rtype: EqlNode
     """
     if not text.strip():
-        raise EqlParseError("No text specified", 0, 0, text)
+        raise EqlSyntaxError("No text specified", 0, 0, text)
 
     # Convert everything to unicode
     text = to_unicode(text)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,8 @@ import os
 import unittest
 
 import eql.utils
-from eql.parser import parse_query, parse_expression, parse_analytic, EqlParseError
+from eql.errors import EqlParseError
+from eql.parser import parse_query, parse_expression, parse_analytic
 from eql.utils import is_stateful, match_kv, get_output_types
 
 


### PR DESCRIPTION
## Issues
None

## Details
Made the missing `where` raise an EqlSyntaxError instead of EqlSemanticError.
This will affect cases like this, when `implied_any` is not enabled:

```python
import eql
eql.parse_query("foo")
eql.parse_query("yes")
```