### PR TITLE
Add SQL-consistent null handling

### DIFF
--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -42,8 +42,6 @@ from .parser import (
     parse_field,
     parse_literal,
     parse_query,
-    skip_optimizations,
-    strict_field_schema,
     extract_query_terms,
 )
 from .schema import Schema
@@ -124,6 +122,4 @@ __all__ = (
     "save_analytic",
     "save_analytics",
     "save_dump",
-    "skip_optimizations",
-    "strict_field_schema",
 )

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -32,6 +32,8 @@ __all__ = (
     # boolean logic
     "Comparison",
     "InSet",
+    "IsNotNull",
+    "IsNull",
     "And",
     "Or",
     "Not",
@@ -580,6 +582,30 @@ class Comparison(Expression):
         if self.comparator == Comparison.EQ and isinstance(other, InSet) and self.left == other.expression:
             return InSet(self.left, [self.right]) & other
         return super(Comparison, self).__and__(other)
+
+
+class IsNull(Expression):
+    """Node for checking if values are null."""
+
+    template = Template("$expr == null")
+    precedence = Comparison.precedence
+    __slots__ = "expr",
+
+    def __init__(self, expr):  # type: (Expression) -> None
+        """Check if a value is null."""
+        self.expr = expr
+
+
+class IsNotNull(Expression):
+    """Node for checking if values are null."""
+
+    template = Template("$expr != null")
+    precedence = Comparison.precedence
+    __slots__ = "expr",
+
+    def __init__(self, expr):  # type: (Expression) -> None
+        """Check if a value is not null."""
+        self.expr = expr
 
 
 class InSet(Expression):

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -188,10 +188,17 @@ class Expression(EqlNode):
 
     def __and__(self, other):
         """Boolean AND between two AST nodes."""
-        if isinstance(other, Literal):
-            if other.value:
-                return self
+        if self == Boolean(False) or other == Boolean(False):
             return Boolean(False)
+        elif self == Boolean(True):
+            return other
+        elif other == Boolean(True):
+            return self
+
+        if isinstance(self, Literal) and isinstance(other, Literal):
+            if self == Null() or other == Null():
+                return Null()
+            return Boolean(bool(self.value) and bool(other.value))
 
         if isinstance(other, And):
             return And([self] + other.terms)
@@ -199,9 +206,17 @@ class Expression(EqlNode):
 
     def __or__(self, other):
         """"Boolean OR between two AST nodes."""
-        if isinstance(other, Literal):
-            if other.value:
-                return Boolean(True)
+        if self == Boolean(True) or other == Boolean(True):
+            return Boolean(True)
+        elif self == Boolean(False):
+            return other
+        elif other == Boolean(False):
+            return self
+
+        if isinstance(self, Literal) and isinstance(other, Literal):
+            if self == Null() or other == Null():
+                return Null()
+            return Boolean(bool(self.value) and bool(other.value))
 
         if isinstance(other, Or):
             return Or([self] + other.terms)
@@ -245,24 +260,6 @@ class Literal(Expression):
         subcls = cls.find_type(python_value)
         return subcls(python_value)
 
-    def __and__(self, other):
-        """Shortcut ANDing of Static Value nodes together."""
-        if isinstance(other, Literal):
-            return Boolean(self.value and other.value)
-        elif self.value:
-            return other
-        else:
-            return Boolean(False)
-
-    def __or__(self, other):
-        """Shortcut ORing of Static Value nodes together."""
-        if isinstance(other, Literal):
-            return Boolean(self.value or other.value)
-        elif self.value:
-            return self
-        else:
-            return other
-
     def __invert__(self):
         """Negate a static value."""
         return Boolean(not self.value)
@@ -285,6 +282,10 @@ class Null(Literal):
     def __init__(self, value=None):
         """Null literal value."""
         super(Null, self).__init__(None)
+
+    def __invert__(self):
+        """Null values can't be inverted."""
+        return Null()
 
     def _render(self):
         return 'null'

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -121,6 +121,44 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         else:
             return output_results
 
+    @classmethod
+    def null_checked(cls, f):
+        """Helper decorator for checking null values."""
+        @functools.wraps(f)
+        def decorated(*args):
+            # null can only be compared with IsNull/IsNotNull
+            if any(arg is None for arg in args):
+                return
+
+            return f(*args)
+
+        return decorated
+
+    @classmethod
+    def check_types(cls, f):
+        """Helper decorator for performing type checks before evaluating comparisons."""
+        @functools.wraps(f)
+        def decorated(a, b):
+            if is_string(a) and is_string(b) or \
+                    is_number(a) and is_number(b) or \
+                    type(a) == type(b):
+                return f(a, b)
+
+        return decorated
+
+    @classmethod
+    def lowercase(cls, f, always=True):
+        """Decorator function for lowercasing values to perform case-insensitive comparisons."""
+        @functools.wraps(f)
+        def decorated(a, b):
+            if is_string(a) and is_string(b):
+                return f(a.lower(), b.lower())
+
+            if not always:
+                return f(a, b)
+
+        return decorated
+
     def convert(self, node, *args, **kwargs):
         """Convert an eql AST to a python callback function.
 
@@ -229,7 +267,9 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         get_value = self.convert(node.term)
 
         def negate(scope):  # type: (Scope) -> bool
-            return not get_value(scope)
+            value = get_value(scope)
+            if value is not None:
+                return not value
 
         return negate
 
@@ -383,6 +423,9 @@ class PythonEngine(BaseEngine, BaseTranspiler):
 
             def callback(scope):  # type: (Scope) -> bool
                 check_value = get_value(scope)
+                if check_value is None:
+                    return
+
                 if is_string(check_value):
                     check_value = check_value.lower()
                 return check_value in values
@@ -392,45 +435,23 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         else:
             return self.convert(node.synonym)
 
+    def _convert_is_null(self, node):  # type: (IsNull) -> callable
+        get_value = self.convert(node.expr)
+        return lambda x: get_value(x) is None
+
+    def _convert_is_not_null(self, node):  # type: (IsNotNull) -> callable
+        get_value = self.convert(node.expr)
+        return lambda x: get_value(x) is not None
+
     def _convert_comparison(self, node):  # type: (Comparison) -> callable
         get_left = self.convert(node.left)
         get_right = self.convert(node.right)
 
-        def types_match(x, y):
-            return (
-                    type(x) == type(y) or
-                    is_string(x) and is_string(y) or
-                    is_number(x) and is_number(y)
-            )
-
-        def equals(x, y):
-            if not types_match(x, y):
-                return False
-            elif is_string(x):
-                return x.lower() == y.lower()
-            else:
-                return x == y
-
-        # Create different comparison functions so that this if statement doesn't need to be evaluated every time
-        if node.comparator == Comparison.EQ:
-            compare = equals
-        elif node.comparator == Comparison.NE:
-            def compare(x, y):
-                return not equals(x, y)
-        elif node.comparator == Comparison.LT:
-            def compare(x, y):
-                return types_match(x, y) and x < y
-        elif node.comparator == Comparison.LE:
-            def compare(x, y):
-                return types_match(x, y) and x <= y
-        elif node.comparator == Comparison.GT:
-            def compare(x, y):
-                return types_match(x, y) and x > y
-        elif node.comparator == Comparison.GE:
-            def compare(x, y):
-                return types_match(x, y) and x >= y
+        # perform string-insensitive checks for == and !=
+        if node.comparator in (Comparison.EQ, Comparison.NE):
+            compare = self.check_types(self.lowercase(node.function, always=False))
         else:
-            raise EqlCompileError("Unknown comparator {}".format(node.comparator))
+            compare = self.check_types(node.function)
 
         def callback(scope):  # type: (Scope) -> bool
             left = get_left(scope)
@@ -442,19 +463,54 @@ class PythonEngine(BaseEngine, BaseTranspiler):
     def _convert_math_operation(self, node):  # type: (MathOperation) -> callable
         return self.convert(node.to_function_call())
 
-    def _convert_and(self, node):  # type: (CompoundTerm) -> callable
+    @staticmethod
+    def to_bool_or_null(obj):  # type: (object) -> bool
+        """Helper function for aggregating boolean logic."""
+        if obj is not None:
+            return bool(obj)
+
+    def _convert_and(self, node):  # type: (And) -> callable
         get_terms = [self.convert(term) for term in node.terms]
+        first = get_terms[0]
+        rest = get_terms[1:]
 
         def and_terms(scope):  # type: (Scope) -> bool
-            return all(get_term(scope) for get_term in get_terms)
+            aggregate = self.to_bool_or_null(first(scope))
+
+            if aggregate is False:
+                return False
+
+            for term in rest:
+                value = self.to_bool_or_null(term(scope))
+                if value is False:
+                    return False
+                elif value is None:
+                    aggregate = None
+
+            return aggregate
 
         return and_terms
 
-    def _convert_or(self, node):  # type: (CompoundTerm) -> callable
+    def _convert_or(self, node):  # type: (Or) -> callable
         get_terms = [self.convert(term) for term in node.terms]
+        first = get_terms[0]
+        rest = get_terms[1:]
 
         def or_terms(scope):  # type: (Scope) -> bool
-            return any(get_term(scope) for get_term in get_terms)
+            aggregate = self.to_bool_or_null(first(scope))
+
+            if aggregate is True:
+                return True
+
+            for term in rest:
+                value = self.to_bool_or_null(term(scope))
+
+                if value is True:
+                    return True
+                elif value is None:
+                    aggregate = None
+
+            return aggregate
 
         return or_terms
 

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -139,6 +139,9 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         """Helper decorator for performing type checks before evaluating comparisons."""
         @functools.wraps(f)
         def decorated(a, b):
+            if a is None or b is None:
+                return
+
             if is_string(a) and is_string(b) or \
                     is_number(a) and is_number(b) or \
                     type(a) == type(b):

--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -67,53 +67,53 @@ process where serial_event_id<=8 and serial_event_id > 7
 expected_event_ids  = [8]
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code >= 0'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where 0 <= exit_code'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code <= 0'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code < 1'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code > -1'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where -1 < exit_code'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids = []
 query = '''
-process where not (exit_code > -1)
+process where null == (exit_code > -1)
   and serial_event_id in (58, 64, 69, 74, 80, 85, 90, 93, 94)
 | head 10
 '''
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [1, 2, 3, 4, 5, 6, 7]
-query = 'process where not (exit_code > -1) | head 7'
+query = 'process where null == (exit_code > -1) | head 7'
 
 [[queries]]
-note = "check that comparisons against null values return false"
+note = "check that comparisons against null values return null"
 expected_event_ids  = [1, 2, 3, 4, 5, 6, 7]
-query = 'process where not (-1 < exit_code) | head 7'
+query = 'process where null == (-1 < exit_code) | head 7'
 
 [[queries]]
 query = 'process where exit_code > 0'
@@ -152,19 +152,22 @@ expected_event_ids  = [3, 34, 48]
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe", "Explorer.exe")
-| unique length(process_name)'''
+| unique length(process_name)
+'''
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
-| unique length(process_name) == length("python.exe")'''
+| unique length(process_name) == length("python.exe")
+'''
 expected_event_ids  = [3, 48]
 
 [[queries]]
 query = '''
 process where process_name in ("Python.exe", "smss.exe", "explorer.exe")
-| unique process_name != "python.exe"'''
+| unique process_name != "python.exe"
+'''
 expected_event_ids  = [3, 48]
 
 [[queries]]
@@ -214,7 +217,8 @@ expected_event_ids  = [79]
 
 [[queries]]
 query = '''
-process where process_path == "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)'''
+process where process_path == "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)
+'''
 expected_event_ids  = [84, 85]
 
 [[queries]]
@@ -940,51 +944,57 @@ description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plore') == 2 and not indexOf(file_name, '.pf')
+file where opcode=0 and indexOf(file_name, 'plore') == 2 and indexOf(file_name, '.pf') == null
 '''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.') and indexOf(file_name, 'plore', 100)
+file where opcode=0 and indexOf(file_name, 'explorer.') > 0 and indexOf(file_name, 'plore', 100) > 0
 '''
 expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 0) == 2'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 0) == 2
+'''
 expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2)'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) != null
+'''
 expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 4)'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 4) != null
+'''
 expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'thing that never happened')'''
+file where opcode=0 and indexOf(file_name, 'thing that never happened') != null
+'''
 expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'plorer.', 2) == 2'''
+file where opcode=0 and indexOf(file_name, 'plorer.', 2) == 2
+'''
 expected_event_ids  = [88, 92]
 description = "check substring ranges"
 
 [[queries]]
 query = '''
-file where opcode=0 and indexOf(file_name, 'explorer.', 0) == 0'''
+file where opcode=0 and indexOf(file_name, 'explorer.', 0) == 0
+'''
 expected_event_ids  = [88, 92]
 description = "check substring ranges"
 
@@ -1018,31 +1028,36 @@ description = "check substring ranges"
 
 [[queries]]
 query = '''
-process where add(serial_event_id, 0) == 1 and add(0, 1) == serial_event_id'''
+process where add(serial_event_id, 0) == 1 and add(0, 1) == serial_event_id
+'''
 expected_event_ids  = [1]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where subtract(serial_event_id, -5) == 6'''
+process where subtract(serial_event_id, -5) == 6
+'''
 expected_event_ids  = [1]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where multiply(6, serial_event_id) == 30 and divide(30, 4.0) == 7.5'''
+process where multiply(6, serial_event_id) == 30 and divide(30, 4.0) == 7.5
+'''
 expected_event_ids  = [5]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where modulo(11, add(serial_event_id, 1)) == serial_event_id'''
+process where modulo(11, add(serial_event_id, 1)) == serial_event_id
+'''
 expected_event_ids  = [1, 2, 3, 5, 11]
 description = "test built-in math functions"
 
 [[queries]]
 query = '''
-process where serial_event_id == number('5')'''
+process where serial_event_id == number('5')
+'''
 expected_event_ids  = [5]
 description = "test string/number conversions"
 
@@ -1050,19 +1065,16 @@ description = "test string/number conversions"
 expected_event_ids  = [50]
 description = "test string/number conversions"
 query = '''
-process where serial_event_id == number('0x32', 16)'''
+process where serial_event_id == number('0x32', 16)
+'''
 
 [[queries]]
 expected_event_ids  = [50]
 description = "test string/number conversions"
 query = '''
-process where serial_event_id == number('32', 16)'''
+process where serial_event_id == number('32', 16)
+'''
 
-[[queries]]
-query = '''
-process where number(serial_event_id) == number(5)'''
-expected_event_ids  = [5]
-description = "test string/number conversions"
 
 [[queries]]
 query = '''
@@ -1074,7 +1086,8 @@ description = "test string concatenation"
 [[queries]]
 query = '''
 process where process_name != original_file_name
-| filter length(original_file_name) > 0'''
+| filter length(original_file_name) > 0
+'''
 expected_event_ids = []
 description = "check that case insensitive comparisons are performed for fields."
 
@@ -1088,13 +1101,15 @@ description = "test that process sequences are working correctly"
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
-registry where arraySearch(bytes_written_string_list, a, a == 'en-us')'''
+registry where arraySearch(bytes_written_string_list, a, a == 'en-us')
+'''
 
 [[queries]]
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
-registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))'''
+registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))
+'''
 
 [[queries]]
 expected_event_ids  = [75305]

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -638,7 +638,7 @@ class LarkToEQL(Interpreter):
 
         # if there are an odd number of NOTs then we negate
         if len(node.get_list("NOT_OP")) % 2 == 1:
-            term.node = ~term.node
+            term.node = ast.Not(term.node)
 
         return term
 

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -22,21 +22,24 @@ from .schema import EVENT_TYPE_ANY, EVENT_TYPE_GENERIC, Schema
 from .utils import to_unicode, load_extensions, ParserConfig, is_string
 
 __all__ = (
+    "allow_enum_fields",
+    "extract_query_terms",
     "get_preprocessor",
+    "ignore_missing_fields",
+    "ignore_missing_functions",
+    "implied_booleans",
+    "non_nullable_fields",
+    "nullable_fields",
+    "parse_analytic",
+    "parse_analytics",
     "parse_definition",
     "parse_definitions",
     "parse_expression",
     "parse_field",
     "parse_literal",
     "parse_query",
-    "parse_analytic",
-    "parse_analytics",
-    "ignore_missing_fields",
-    "ignore_missing_functions",
     "skip_optimizations",
-    "strict_field_schema",
-    "allow_enum_fields",
-    "extract_query_terms",
+    "strict_booleans",
 )
 
 
@@ -66,8 +69,12 @@ NON_SPACE_WS = re.compile(r"[^\S ]+")
 skip_optimizations = ParserConfig(optimized=False)
 ignore_missing_functions = ParserConfig(check_functions=False)
 ignore_missing_fields = ParserConfig(ignore_missing_fields=False)
-strict_field_schema = ParserConfig(strict_fields=True, implied_booleans=False)
+implied_booleans = ParserConfig(implied_booleans=True)
+strict_booleans = ParserConfig(implied_booleans=False)
+nullable_fields = ParserConfig(strict_fields=False)
+non_nullable_fields = ParserConfig(strict_fields=True)
 allow_enum_fields = ParserConfig(enable_enum=True)
+
 
 keywords = ("and", "by", "const", "false", "in", "join", "macro",
             "not", "null", "of", "or", "sequence", "true", "until", "with", "where"
@@ -136,7 +143,7 @@ class LarkToEQL(Interpreter):
             self._function_lookup[signature.name] = signature
 
         self._allowed_pipes = ParserConfig.read_stack("allowed_pipes", set(pipes.list_pipes()))
-        self._implied_booleans = ParserConfig.read_stack("implied_booleans", True)
+        self._implied_booleans = ParserConfig.read_stack("implied_booleans", False)
         self._in_pipes = False
         self._event_types = []
         self._schema = Schema.current()
@@ -343,7 +350,7 @@ class LarkToEQL(Interpreter):
     def literal(self, node):
         """Callback function to walk the AST."""
         value = ast.Literal.from_python(self.visit_children(node)[0])
-        return NodeInfo(value, value.type_hint, source=node)
+        return NodeInfo(value, value.type_hint, nullable=not self._strict_fields, source=node)
 
     def time_range(self, node):
         """Callback function to walk the AST."""
@@ -401,7 +408,7 @@ class LarkToEQL(Interpreter):
 
                 if base_hint is not None and base_hint[0] == TypeHint.String:
                     comparison = ast.Comparison(base_field, ast.Comparison.EQ, enum_value)
-                    return NodeInfo(comparison, TypeHint.String, nullable=not self._strict_fields, source=node_info)
+                    return NodeInfo(comparison, TypeHint.Boolean, nullable=not self._strict_fields, source=node_info)
 
         else:
             type_hint = self._var_types[field.base]
@@ -429,6 +436,7 @@ class LarkToEQL(Interpreter):
         for prev_node, function_node in zip(node.children[:-1], node.children[1:]):
             rv = self.function_call(function_node, prev_node, rv)
 
+        rv.source = node
         return rv
 
     def value(self, node):
@@ -533,13 +541,28 @@ class LarkToEQL(Interpreter):
         accepted_types = TypeHint.primitives()
         error_message = "Invalid comparison of {expected_type} to {actual_type}"
 
+        def check_null(expr, null_side):
+            # check for `expr == null` or `expr != null`
+            if isinstance(null_side.node, ast.Null) and op in (ast.Comparison.NE, ast.Comparison.EQ):
+                if not expr.validate_type(TypeHint.Null):
+                    # check if the types can actually be compared, and don't allow comparison of nested types
+                    raise self._type_error(left, TypeHint.Null, error_message, error_node=node)
+
+                comp = ast.IsNull(expr.node) if op == ast.Comparison.EQ else ast.IsNotNull(expr.node)
+                return NodeInfo(comp, TypeHint.Boolean, nullable=not self._strict_fields)
+
+        comp = check_null(left, right) or check_null(right, left)
+
+        if comp is not None:
+            return comp
+
         if not left.validate_type(accepted_types) or \
                 not right.validate_type(accepted_types) or \
                 not right.validate_type(left):
             # check if the types can actually be compared, and don't allow comparison of nested types
             raise self._type_error(right, left, error_message, error_node=node)
 
-        if op in (ast.Comparison.LT, ast.Comparison.LE, ast.Comparison.GE, ast.Comparison.GE):
+        if op in (ast.Comparison.LT, ast.Comparison.LE, ast.Comparison.GE, ast.Comparison.GT):
             # check that <, <=, >, >= are only supported for strings or numbers
             if not (left.validate_type(TypeHint.Numeric) and right.validate_type(TypeHint.Numeric) or
                     left.validate_type(TypeHint.String) and right.validate_type(TypeHint.String)):
@@ -557,7 +580,7 @@ class LarkToEQL(Interpreter):
             elif op == ast.Comparison.NE:
                 eql_node = ~func_call
 
-        return NodeInfo(eql_node, TypeHint.Boolean, nullable=False, source=node)
+        return NodeInfo(eql_node, TypeHint.Boolean, nullable=left.nullable or right.nullable, source=node)
 
     def mathop(self, node):
         """Callback function to walk the AST."""
@@ -641,7 +664,8 @@ class LarkToEQL(Interpreter):
 
         # This will always evaluate to true/false, so it should be a boolean
         term = ast.InSet(outer.node, [c.node for c in container])
-        return NodeInfo(term, TypeHint.Boolean, nullable=False, source=node)
+        nullable = outer.nullable or any(c.nullable for c in container)
+        return NodeInfo(term, TypeHint.Boolean, nullable=nullable, source=node)
 
     def _get_type_hint(self, node, ast_node):
         """Get the recommended type hint for a node when it isn't already known.
@@ -735,7 +759,8 @@ class LarkToEQL(Interpreter):
             self._var_types = old_variables
 
             expr = ast.FunctionCall(function_name, [a.node for a in args], as_method=prev_node is not None)
-            return NodeInfo(expr, signature.return_value, nullable=False, source=node)
+            nullable = any(a.nullable for a in args) or signature.sometimes_null
+            return NodeInfo(expr, signature.return_value, nullable=nullable, source=node)
 
         elif self._check_functions:
             raise self._error(node["name"], "Unknown function {NAME}")

--- a/eql/types.py
+++ b/eql/types.py
@@ -56,7 +56,7 @@ class TypeFoldCheck(object):
 class NodeInfo(object):
     """Class for holding full type and schema information for an expression."""
 
-    def __init__(self, node, type_info=None, nullable=False, schema=None, source=None):
+    def __init__(self, node, type_info=None, nullable=True, schema=None, source=None):
         """Capture node information for an AST.
 
         :param ast.EqlNode node: The EQL node in the tree.
@@ -95,10 +95,10 @@ class NodeInfo(object):
             other_nullable = expected.nullable
         elif isinstance(expected, TypeHint):
             other_type = expected
-            other_nullable = other_type in (TypeHint.Null, TypeHint.Unknown)
+            other_nullable = True
         elif isinstance(expected, TypeFoldCheck):
             other_type = expected.type_info
-            other_nullable = other_type in (TypeHint.Null, TypeHint.Unknown)
+            other_nullable = True
         else:
             raise TypeError("Expected one of {}, got {}", (NodeInfo, TypeHint, TypeFoldCheck), expected)
 

--- a/tests/test_nulls.py
+++ b/tests/test_nulls.py
@@ -1,0 +1,101 @@
+"""Test Python Engine for EQL."""
+import unittest
+
+from eql.ast import Literal, Not, Null
+from eql.engine import PythonEngine
+from eql.parser import parse_expression, skip_optimizations
+
+from . import utils
+
+
+class TestPythonEngine(unittest.TestCase):
+    """Test correctness of null handling through the optimizer and Python Engine."""
+
+    @staticmethod
+    def engine_eval(expr):
+        """Evaluate an unoptimized expression in the ``PythonEngine``."""
+        return PythonEngine().convert(expr)(None)
+
+    def test_null_or_handling(self):
+        """Test that nulls are correctly propagated through ``or`` for the engine and optimizer."""
+        engine = PythonEngine()
+
+        def engine_eval(expr):
+            return engine.convert(expr)(None)
+
+        with skip_optimizations:
+            expected = [
+                ("true  or false", True),
+                ("true  or null ", True),
+                ("true  or true ", True),
+                ("false or null ", None),
+                ("false or false", False),
+                ("false or true ", True),
+                ("null  or false", None),
+                ("null  or null ", None),
+                ("null  or true ", True),
+            ]
+
+            for text, output in expected:
+                parsed = parse_expression(text)
+                self.assertNotIsInstance(parsed,  Literal)
+                self.assertEqual(engine_eval(parsed), output, "for: {} == {}".format(text, output))
+                self.assertEqual(parsed.fold(), output, "for: {} == {}".format(text, output))
+
+    def test_null_and_handling(self):
+        """Test that nulls are correctly propagated through ``and``."""
+        with skip_optimizations:
+            expected = [
+                ("true  and false",  False),
+                ("true  and null ", None),
+                ("true  and true ", True),
+                ("false and null ", False),
+                ("false and false", False),
+                ("false and true ", False),
+                ("null  and false", False),
+                ("null  and null ", None),
+                ("null  and true ", None),
+            ]
+
+            for text, output in expected:
+                parsed = parse_expression(text)
+                self.assertNotIsInstance(parsed,  Literal)
+                self.assertEqual(self.engine_eval(parsed), output, "for: {} == {}".format(text, output))
+                self.assertEqual(parsed.fold(), output, "for: {} == {}".format(text, output))
+
+    def test_null_compares(self):
+        """Test that all types can be compared to null."""
+        values = [None, utils.random_bool(), utils.random_int(), utils.random_string(), utils.random_float()]
+
+        with skip_optimizations:
+            for v in values:
+                unparsed = utils.unfold(v)
+
+                def folds_to(fmt_string, expected):
+                    parsed = parse_expression(fmt_string.format(unparsed))
+                    self.assertNotIsInstance(parsed, Literal)
+                    self.assertEqual(parsed.fold(), expected)
+                    self.assertEqual(self.engine_eval(parsed), expected)
+
+                folds_to("{}   == null", v is None)
+                folds_to("{}   != null", v is not None)
+                folds_to("null ==   {}", v is None)
+                folds_to("null !=   {}", v is not None)
+
+                if not isinstance(v, bool):
+                    folds_to("{} <    null", None)
+                    folds_to("{}   <= null", None)
+                    folds_to("{}   >  null", None)
+                    folds_to("{}   >= null", None)
+                    folds_to("null <    {}", None)
+                    folds_to("null <=   {}", None)
+                    folds_to("null >=   {}", None)
+                    folds_to("null >    {}", None)
+
+    def test_not_null(self):
+        """Test that ``not null`` returns ``null``."""
+        with skip_optimizations:
+            parsed = parse_expression("not null")
+            self.assertEqual(parsed, Not(Null()))
+            self.assertEqual(parsed.fold(), None)
+            self.assertEqual(self.engine_eval(parsed), None)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -42,11 +42,18 @@ class TestParser(unittest.TestCase):
             'abc and def',
             '(1==abc) and def',
             '1 * 2 + 3 * 4 + 10 / 2',
-            'abc == (1 and 2)',
-            'abc == (def and 2)',
+
+            # opt-in with eql.parser.implied_booleans
+            # 'abc == (1 and 2)',
+            # 'abc == (def and 2)',
+
             'abc == (def and def)',
             'abc == (def and ghi)',
             '"\\b\\t\\r\\n\\f\\\\\\"\\\'"',
+            '1 - -2',
+            '1 + -2',
+            '1 * (-2)',
+            '3 * -length(file_path)',
         ]
 
         for query in valid:
@@ -160,10 +167,13 @@ class TestParser(unittest.TestCase):
             'image_load where not x > y',
             'process where _leadingUnderscore == 100',
             'network where 1 * 2 + 3 * 4 + 10 / 2 == 2 + 12 + 5',
-            'file where 1 - -2',
-            'file where 1 + (-2)',
-            'file where 1 * (-2)',
-            'file where 3 * -length(file_path)',
+
+            # now requires eql.parser.implied_booleans
+            # 'file where (1 - -2)',
+            # 'file where 1 + (-2)',
+            # 'file where 1 * (-2)',
+            # 'file where 3 * -length(file_path)',
+
             'network where a * b + c * d + e / f == g + h + i',
             'network where a * (b + c * d) + e / f == g + h + i',
             'process where pid == 4 or pid == 5 or pid == 6 or pid == 7 or pid == 8',
@@ -213,8 +223,8 @@ class TestParser(unittest.TestCase):
             # multiple by values
             'sequence by field1  [file where true] by f1 [process where true] by f1',
             'sequence by a,b,c,d [file where true] by f1,f2 [process where true] by f1,f2',
-            'sequence [file where 1] by f1,f2 [process where 1] by f1,f2 until [process where 1] by f1,f2',
-            'sequence by f [file where true] by a,b [process where true] by c,d until [process where 1] by e,f',
+            'sequence [file where 1=1] by f1,f2 [process where 1=1] by f1,f2 until [process where 1=1] by f1,f2',
+            'sequence by f [file where true] by a,b [process where true] by c,d until [process where 1=1] by e,f',
             # sequence with named params
             'sequence by unique_pid [process where true] [file where true] fork',
             'sequence by unique_pid [process where true] [file where true] fork=true',
@@ -371,7 +381,7 @@ class TestParser(unittest.TestCase):
     def test_method_syntax(self):
         """Test correct parsing and rendering of methods."""
         parse1 = parse_expression("(a and b):concat():length()")
-        parse2 = parse_expression("a and b:concat():length()")
+        parse2 = parse_expression("a and b:concat():length() > 0")
         self.assertNotEqual(parse1, parse2)
 
         class Unmethodize(DepthFirstWalker):

--- a/tests/test_python_engine.py
+++ b/tests/test_python_engine.py
@@ -355,6 +355,7 @@ class TestPythonEngine(TestEngine):
         return x
 
     @staticmethod
+    @PythonEngine.null_checked
     def _custom_reverse(x):
         return x[::-1]
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,7 +3,7 @@ import unittest
 
 from eql.events import Event
 from eql.errors import EqlSchemaError, EqlTypeMismatchError
-from eql.parser import parse_query, strict_field_schema, allow_enum_fields
+from eql.parser import parse_query, strict_booleans, non_nullable_fields, allow_enum_fields
 from eql.schema import Schema
 from eql.types import TypeHint
 
@@ -75,28 +75,29 @@ class TestSchemaValidation(unittest.TestCase):
                 self.assertRaises(EqlSchemaError, parse_query, query)
 
     def test_valid_schema_fields(self):
-        """Test that schema errors are being raised separately."""
+        """Test that schema errors are never raised for valid schema usage."""
         valid = [
-            'process where process_name == "test" and command_line == "test" and not pid',
+            'process where process_name == "test" and command_line == "test" and pid > 0',
             'file where file_path == "abc" and data == 1',
             'file where file_path == "abc" and data == "fdata.exe"',
-            'file where file_path == "abc" and not data',
-            'file where file_path == "abc" and length(data) | filter file_path == "abc"',
+            'file where file_path == "abc" and data != null',
+            'file where file_path == "abc" and length(data) > 0 | filter file_path == "abc"',
             'sequence [file where pid=1] [process where pid=2] | filter events[0].file_name = events[1].process_name',
-            'sequence by pid [file where 1] [process where 1] | filter events[0].file_name = events[1].process_name',
-            'join by pid [file where 1] [process where 1] | filter events[0].file_name = events[1].process_name',
+            'sequence by pid [file where true] [process where true] ' +
+            '| filter events[0].file_name = events[1].process_name',
+            'join by pid [file where true] [process where true] | filter events[0].file_name = events[1].process_name',
 
-            'join [file where 1] by pid [process where 1] by pid until [complex where 0] by nested.num'
+            'join [file where true] by pid [process where true] by pid until [complex where false] by nested.num'
             '| filter events[0].file_name = events[1].process_name',
 
-            'complex where string_arr[3]',
+            'complex where string_arr[3] != null',
             'complex where wideopen.a.b[0].def == 1',
-            'complex where nested.arr',
+            'complex where length(nested.arr) > 0',
             'complex where nested.arr[0] == 1',
             'complex where nested.double_nested.nn == 5',
-            'complex where nested.double_nested.triplenest',
+            'complex where nested.double_nested.triplenest != null',
             'complex where nested.double_nested.triplenest.m == 5',
-            'complex where nested.  double_nested.triplenest.b',
+            'complex where nested.  double_nested.triplenest.b != null',
         ]
 
         with Schema(self.schema):
@@ -124,10 +125,10 @@ class TestSchemaValidation(unittest.TestCase):
             'process where wideopen.a.b.c',
             'any where invalid_field',
             'complex where nested.  double_nested.b',
-            'file where file_path == "abc" and length(data) | unique missing_field == "abc"',
+            'file where file_path == "abc" and data != null | unique missing_field == "abc"',
             'sequence [file where pid=1] [process where pid=2] | filter events[0].file_name = events[1].bad',
 
-            'sequence [file where 1] by pid [process where 1] by pid until [complex where 0] by pid'
+            'sequence [file where 1=1] by pid [process where 1=1] by pid until [complex where false] by pid'
             '| unique events[0].file_name = events[1].process_name',
         ]
         with Schema(self.schema):
@@ -170,13 +171,24 @@ class TestSchemaValidation(unittest.TestCase):
         queries = [
             "process where command_line != null",
             "process where elevated != null",
-            # explicit boolean checking
-            "process where process_name and command_line",
-            "process where 1 and 2",
-            "process where command_line",
+            "process where pid != null",
+            "process where pid > null",
+
+            # constants also aren't comparable to null
+            "process where 5 > null",
+            "process where 5 != null",
+
+            "process where (pid == 0 or process_name == 'foo') == null",
+
+            "process where indexOf(null, null)",
+
+            "process where (process_name in ('net.exe')) != null",
+            "process where (pid > 0) != null",
+            "process where (pid > 0) != null",
+            "process where substring(process_name, 1) == null",
         ]
 
-        with strict_field_schema, Schema(self.schema):
+        with strict_booleans, non_nullable_fields, Schema(self.schema):
             for query in queries:
                 self.assertRaises(EqlTypeMismatchError, parse_query, query)
 
@@ -186,9 +198,15 @@ class TestSchemaValidation(unittest.TestCase):
             "process where command_line != 'abc.exe'",
             "process where elevated != true",
             "process where not elevated",
+
+            # functions that may return null, even with non-null inputs can be compared
+            "process where indexOf(process_name, 'foo') != null",
+
+            # since indexOf can be passed into other functions, any can be null
+            "process where substring(process_name, indexOf(process_name, 'foo')) == null",
         ]
 
-        with strict_field_schema, Schema(self.schema):
+        with strict_booleans, non_nullable_fields, Schema(self.schema):
             for query in queries:
                 parse_query(query)
 
@@ -197,7 +215,7 @@ class TestSchemaValidation(unittest.TestCase):
         queries = [
             "process where true | count | filter key == 'total' and percent < 0.5 and count > 0",
             "process where true | unique_count process_name | filter count > 5 and process_name == '*.exe'",
-            "sequence[file where 1][process where 1] | unique_count events[0].process_name" +
+            "sequence[file where true][process where true] | unique_count events[0].process_name" +
             " | filter count > 5 and events[1].elevated",
         ]
 
@@ -211,13 +229,13 @@ class TestSchemaValidation(unittest.TestCase):
             "process where true | count | filter key == 'total' and percent < 0.5 and count > 0 and elevated",
             "process where true | unique_count process_name | filter key == '*.abc'" +
             " and count > 5 and process_name == '*.exe'",
-            "sequence[file where 1][process where 1] | unique_count events[0].process_name" +
+            "sequence[file where true][process where true] " +
+            " | unique_count events[0].process_name" +
             " | filter count > 5 and events[0].elevated",
         ]
 
         with Schema(self.schema):
             for query in queries:
-                print(query)
                 self.assertRaises(EqlSchemaError, parse_query, query)
 
     def test_merge_schema(self):

--- a/tests/test_type_system.py
+++ b/tests/test_type_system.py
@@ -55,32 +55,6 @@ class TestTypeSystem(unittest.TestCase):
             output = NodeInfo(None, hint1).validate_type(hint2)
             self.assertEqual(output, expected, "hint {}.validate({}) != {}".format(hint1, hint2, expected))
 
-    def test_null_compares(self):
-        """Test that all types can be compared to null."""
-        values = [None, utils.random_bool(), utils.random_int(), utils.random_string(), utils.random_float()]
-
-        for v in values:
-            unparsed = utils.unfold(v)
-
-            def folds_to(fmt_string, expected):
-                parsed = parse_expression(fmt_string.format(unparsed))
-                self.assertEqual(parsed.fold(), expected)
-
-            folds_to("{}   == null", v is None)
-            folds_to("{}   != null", v is not None)
-            folds_to("null ==   {}", v is None)
-            folds_to("null !=   {}", v is not None)
-
-            if not isinstance(v, bool):
-                folds_to("{} <    null", None)
-                folds_to("{}   <= null", None)
-                folds_to("{}   >  null", None)
-                folds_to("{}   >= null", None)
-                folds_to("null <    {}", None)
-                folds_to("null <=   {}", None)
-                folds_to("null >=   {}", None)
-                folds_to("null >    {}", None)
-
     def test_type_match_comparisons(self):
         """Test that all valid non-null type comparisons."""
         comparables = [
@@ -137,7 +111,7 @@ class TestTypeSystem(unittest.TestCase):
                     parse_expression("{left} {comp} {right}".format(left=left, comp=comparison, right=right))
 
     def test_parse_implied_booleans(self):
-        """Test that parsing with implicit boolean casting works."""
+        """Test that parsing with implicit boolean casting works as expected."""
         with implied_booleans:
             for num_bools in range(2, 10):
                 values = [utils.unfold(utils.random_value()) for _ in range(num_bools)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -81,8 +81,6 @@ class TestUtils(unittest.TestCase):
             """Helper function for validation."""
             condition_node = match_kv(condition_dict)
             parsed_node = parse_expression(condition_text)
-            print(condition_node)
-            print(parsed_node)
             self.assertEqual(condition_node.render(), parsed_node.render(), *args)
 
         assert_kv_match({"name": "net.exe"},

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,58 @@
+"""Utility functions for testing."""
+
+import random
+import string
+
+from eql.ast import Expression, Literal
+from eql.parser import parse_expression
+from eql.utils import is_string
+
+
+MAX_INT = int(2 ^ 63 - 1)
+MIN_INT = int(- (2 ^ 63))
+
+LETTERS = string.printable
+
+
+def fold(expr):
+    """Test method for parsing and folding."""
+    if is_string(expr):
+        expr = parse_expression(expr)
+        return expr.fold()
+    elif isinstance(expr, Expression):
+        return expr.fold()
+    else:
+        raise TypeError("Unable to fold {}".format(expr))
+
+
+def unfold(value):
+    """Convert a python constant into an unparsed EQL expression."""
+    return Literal.from_python(value).render()
+
+
+def random_int():
+    """Generate a random integer value."""
+    return random.randint(MIN_INT, MAX_INT)
+
+
+def random_string(max_len=64):
+    """Generate a random string."""
+    return ''.join(random.choice(LETTERS) for _ in range(max_len))
+
+
+def random_bool():
+    """Choose between ``True`` and ``False``."""
+    return random.choice([True, False])
+
+
+def random_float(scale=100000):
+    """Generate a random float within ``scale`` of a maximum range."""
+    return random.uniform(-scale, +scale)
+
+
+def random_value():
+    """Choose a random value of a random type."""
+    return random.choice(RANDOM_GETTERS)()
+
+
+RANDOM_GETTERS = [random_int, random_string, random_bool, random_float]


### PR DESCRIPTION
## Issues
Relates to #15

Null is handled differently (and better) in Elasticsearch SQL. This change will backport that handling to Python EQL, and eventually all versions transpiled from this. 

## Details
There's some fancy wikipedia on three-value logic for background here:
https://en.wikipedia.org/wiki/Three-valued_logic

The basic gist of how null will be handled in EQL is this:
* If you want to specifically check against null, you have to use `{{ x }} == null` or `{{ x }} != null`. This is commutative, so you can have the null check on the left or right side.
* Any other comparisons with `null` are undefined and return `null`.
    * For example, if `process_name` is `null` and `parent_process_name`  is `null`, then comparing the two will actually be `null`, not `true`. This does change the existing behavior, but for the better.
    * The only defined behaviors: `null and false` is false, because you know anything ANDed  with false must be false.
    * Similarly, `null or true` is `true`.
* Boolean logic short circuiting is almost the same, but `and` and  `any` don't work any more. The one difference is that to get the value of `null and {{ x }}`, you have to evaluate `{{ x }}`. Before, null was treated the same as false for boolean logic, so this would exit sooner.
* I also added a `sometimes_null` value to FunctionSignature, to denote when functions can return `null` even if all of the input parameters are valid and non-null. For instance `indexOf("foo", "bar")` returns `null` because the  string `baz` is not in `foo`, so we can't return an integer offset.