### PR TITLE
Add backticks to the gramar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Version 0.8.7
 _Released 2020-##-##_
 
+### Added
+* Support for escaped identifiers in fields using \`backtick\` syntax
+
 ### Changed
 * (Internal) Changed the type system to use TypeHint/TypeFoldCheck/NodeInfo instead of tuples
 

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -99,7 +99,7 @@ DIGIT: "0".."9"
 LETTER: UCASE_LETTER | LCASE_LETTER
 WORD: LETTER+
 
-ESCAPED_NAME: "`" /[^`]+/ "`"
+ESCAPED_NAME: "`" /[^`\r\n]+/ "`"
 NAME: ("_"|LETTER) ("_"|LETTER|DIGIT)*
 UNSIGNED_INTEGER: /[0-9]+/
 EXPONENT: /[Ee][-+]?\d+/

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -62,7 +62,7 @@ function_call.2: name "(" [expressions] ")"
 ?single_atom: literal
             | field
             | base_field
-base_field: name
+base_field: name | escaped_name
 field: FIELD
 literal: number
        | string
@@ -75,12 +75,23 @@ string: DQ_STRING
 
 // Check against keyword usage
 name: NAME
+escaped_name: ESCAPED_NAME
 
 // Tokens
-// make this a token to avoid ambiguity, and make more rigid on whitespace
+// pin the first "." or "[" to resolve token ambiguities
 // sequence by pid [1] [true] looks identical to:
 // sequence by pid[1] [true]
-FIELD: NAME ("." WHITESPACE* NAME | "[" WHITESPACE* UNSIGNED_INTEGER WHITESPACE* "]")+
+FIELD: FIELD_IDENT (ATTR | INDEX)+
+ATTR: "." WHITESPACE? FIELD_IDENT
+INDEX: "[" WHITESPACE? UNSIGNED_INTEGER WHITESPACE? "]"
+FIELD_IDENT: NAME | ESCAPED_NAME
+
+// create a non-conflicting helper rule to deconstruct
+field_parts: field_ident ("." field_ident | "[" array_index "]")+
+!array_index: UNSIGNED_INTEGER
+!field_ident: NAME | ESCAPED_NAME
+
+
 LCASE_LETTER: "a".."z"
 UCASE_LETTER: "A".."Z"
 DIGIT: "0".."9"
@@ -88,6 +99,7 @@ DIGIT: "0".."9"
 LETTER: UCASE_LETTER | LCASE_LETTER
 WORD: LETTER+
 
+ESCAPED_NAME: "`" /[^`]+/ "`"
 NAME: ("_"|LETTER) ("_"|LETTER|DIGIT)*
 UNSIGNED_INTEGER: /[0-9]+/
 EXPONENT: /[Ee][-+]?\d+/

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,7 +9,7 @@ from eql.ast import *  # noqa: F403
 from eql.errors import EqlSyntaxError, EqlSemanticError, EqlParseError
 from eql.parser import (
     parse_query, parse_expression, parse_definitions, ignore_missing_functions, parse_field, parse_literal,
-    extract_query_terms
+    extract_query_terms, keywords
 )
 from eql.walkers import DepthFirstWalker
 from eql.pipes import *   # noqa: F403
@@ -300,6 +300,29 @@ class TestParser(unittest.TestCase):
         ]
         for query in invalid:
             self.assertRaises(EqlParseError, parse_query, query)
+
+    def test_fields(self):
+        """Test that backticks are accepted with fields."""
+        def parse_to(text, path):
+            node = parse_expression(text)
+            self.assertIsInstance(node, Field)
+            self.assertEqual(node.full_path, path)
+
+            # now render back as text and parse again
+            node2 = parse_expression(node.render())
+            self.assertEqual(node2, node)
+
+        parse_to("`foo-bar-baz`", ["foo-bar-baz"])
+        parse_to("`foo`.`bar-baz`", ["foo", "bar-baz"])
+
+        parse_to("`foo`[0]", ["foo", 0])
+        parse_to("`foo`[0].`bar`", ["foo", 0, "bar"])
+
+        # keywords
+        for keyword in keywords:
+            parse_to("`{keyword}`".format(keyword=keyword), [keyword])
+            parse_to("prefix.`{keyword}`".format(keyword=keyword), ["prefix", keyword])
+            parse_to("`{keyword}`[0].suffix".format(keyword=keyword), [keyword, 0, "suffix"])
 
     def test_query_events(self):
         """Test that event queries work with events[n].* syntax in pipes."""

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -317,7 +317,7 @@ class TestParser(unittest.TestCase):
         parse_to("`foo bar baz`", ["foo bar baz"])
         parse_to("`foo.bar.baz`", ["foo.bar.baz"])
         parse_to("`foo`.`bar-baz`", ["foo", "bar-baz"])
-        parse_to("`foo`.`bar-baz`", ["foo", "bar-baz"])
+        parse_to("`foo.bar-baz`", ["foo.bar-baz"])
         parse_to("`💩`", ["💩"])
 
         parse_to("`foo`[0]", ["foo", 0])

--- a/tests/test_python_engine.py
+++ b/tests/test_python_engine.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 
 from eql import *  # noqa: F403
 from eql.ast import *  # noqa: F403
+from eql.engine import Scope
 from eql.parser import ignore_missing_functions
 from eql.schema import EVENT_TYPE_GENERIC
 from eql.tests.base import TestEngine
@@ -494,3 +495,19 @@ class TestPythonEngine(TestEngine):
         output = self.get_output(queries=[parse_query(query)], config=config, events=events)
         event_ids = [event.data['unique_pid'] for event in output]
         self.validate_results(event_ids, ['host1-1003'], "Relationships failed due to pid collision")
+
+    def test_backticks(self):
+        """Check that backtick fields are indexing into events."""
+        def evaluate(expr, event):
+            engine = PythonEngine()
+            cb = engine.convert(parse_expression(expr))
+            scope = Scope([Event.from_data(event)], None)
+            return cb(scope)
+
+        self.assertIsNone(evaluate("a.b", {}))
+        self.assertEqual(evaluate("a.b", {"a": {"b": 1}}), 1)
+
+        self.assertIsNone(evaluate("`a.b`", {}))
+        self.assertEqual(evaluate("`a.b`", {"a.b": 1}), 1)
+        self.assertEqual(evaluate("a.`b.c`[0]", {"a": {"b.c": [1]}}), 1)
+        self.assertEqual(evaluate("`!@#$%^&*().`", {"!@#$%^&*().": 1}), 1)


### PR DESCRIPTION
## Issues
Relates to #15 
Closes #19 

## Details
Fairly straightforward. Added \`backtick\` support to the grammar and parser.
Validated that the engine is still working as expected.