### PR TITLE
Use integer division when both arguments are integers

### DIFF
--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -1206,8 +1206,12 @@ expected_event_ids = [82]
 query = "file where serial_event_id * 2 == 164"
 
 [[queries]]
-expected_event_ids = [82]
+expected_event_ids = [82, 83]
 query = "file where serial_event_id / 2 == 41"
+
+[[queries]]
+expected_event_ids = [82]
+query = "file where serial_event_id / 2.0 == 41"
 
 [[queries]]
 expected_event_ids = [82]

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -383,7 +383,9 @@ class Divide(MathFunctionSignature):
     def run(cls, x, y):
         """Divide numeric values."""
         if is_number(x) and is_number(y) and y != 0:
-            return float(x) / float(y)
+            if isinstance(x, float) or isinstance(y, float):
+                return float(x) / float(y)
+            return x // y
 
 
 @register

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -462,9 +462,6 @@ class LarkToEQL(Interpreter):
         else:
             value = float(token)
 
-            if int(value) == value:
-                value = int(value)
-
         if node["SIGN"] == "-":
             return -value
         return value


### PR DESCRIPTION
### Issues
Closes #21

### Details
Use integer division if both dividend and divisor are integers. Otherwise, if either is a float, then floating point division is used. In Python 3, the `/` operator is always floating point division, but in Python 2, `/` is type dependent. I switched to `//` for integer division  to be  explicit and maintain compatibility with Python 2.7.