### PR TITLE
Add extra functions to eql.utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.8.7
+_Released 2020-04-06_
+
+### Added
+* Function `eql.utils.get_query_type`
+* Function `eql.utils.get_required_event_types`
+* Function `eql.utils.uses_ancestry`
+
 ## Version 0.8.6
 _Released 2020-04-06_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Version 0.8.7
-_Released 2020-04-06_
+_Released 2020-04-23_
 
 ### Added
 * Function `eql.utils.get_query_type`

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -68,7 +68,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.8.6'
+__version__ = '0.8.7'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/utils.py
+++ b/eql/utils.py
@@ -275,7 +275,7 @@ def match_kv(condition):
     """
     # Resolve circular dependency for match_kv
     from . import ast  # noqa: E402
-    from .parser import parse_expression
+    from .parser import parse_field
 
     if not isinstance(condition, dict):
         raise TypeError("unsupported type {} to match_kv. Expected {}".format(type(condition), ast.EqlNode))
@@ -286,9 +286,7 @@ def match_kv(condition):
         if not isinstance(field_match, (list, tuple)):
             field_match = [field_match]
 
-        field_node = parse_expression(field_text)
-        if not isinstance(field_node, ast.Field):
-            raise TypeError("expected Field as key to dictionary, got {}".format(type(field_node).__name__))
+        field_node = parse_field(field_text)
 
         exact = []
         wildcards = []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -136,7 +136,7 @@ class TestUtils(unittest.TestCase):
     def test_match_kv_errors(self):
         """Test that KV matching raises errors when expected."""
         self.assertRaises(EqlParseError, match_kv, {"invalid^field&syntax": "abc"})
-        self.assertRaises(TypeError, match_kv, {"100": "invalid field"})
+        self.assertRaises(EqlParseError, match_kv, {"100": "invalid field"})
 
         # Test that the parameters are validated
         self.assertRaises(TypeError, match_kv, {"process_name": ["a", tuple()]})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -146,12 +146,10 @@ class TestUtils(unittest.TestCase):
 
     def test_query_type(self):
         """Check eql.utils.get_query_type."""
-        self.assertEqual(eql.utils.get_query_type(parse_query("any where true")), "event")
-        self.assertEqual(eql.utils.get_query_type(parse_query("process where true")), "event")
-        self.assertEqual(eql.utils.get_query_type(parse_query("sequence [process where true] [network where true]")),
-                         "sequence")
-        self.assertEqual(eql.utils.get_query_type(parse_query("join [process where true] [network where true]")),
-                         "join")
+        self.assertEqual(get_query_type(parse_query("any where true")), "event")
+        self.assertEqual(get_query_type(parse_query("process where true")), "event")
+        self.assertEqual(get_query_type(parse_query("sequence [process where true] [network where true]")), "sequence")
+        self.assertEqual(get_query_type(parse_query("join [process where true] [network where true]")), "join")
 
     def test_required_event_types(self):
         """Test that ancestry checks are detected."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import unittest
 import eql.utils
 from eql.errors import EqlParseError
 from eql.parser import parse_query, parse_expression, parse_analytic
-from eql.utils import is_stateful, match_kv, get_output_types
+from eql.utils import is_stateful, match_kv, get_output_types, get_query_type, uses_ancestry, get_required_event_types
 
 
 class TestUtils(unittest.TestCase):
@@ -143,6 +143,75 @@ class TestUtils(unittest.TestCase):
         self.assertRaises(TypeError, match_kv, [])
         self.assertRaises(TypeError, match_kv, True)
         self.assertRaises(TypeError, match_kv, 1)
+
+    def test_query_type(self):
+        """Check eql.utils.get_query_type."""
+        self.assertEqual(eql.utils.get_query_type(parse_query("any where true")), "event")
+        self.assertEqual(eql.utils.get_query_type(parse_query("process where true")), "event")
+        self.assertEqual(eql.utils.get_query_type(parse_query("sequence [process where true] [network where true]")),
+                         "sequence")
+        self.assertEqual(eql.utils.get_query_type(parse_query("join [process where true] [network where true]")),
+                         "join")
+
+    def test_required_event_types(self):
+        """Test that ancestry checks are detected."""
+        self.assertSetEqual(get_required_event_types(parse_query("file where true")), {"file"})
+
+        self.assertSetEqual(get_required_event_types(parse_query("any where event of [process where true]")),
+                            {"any", "process"})
+        self.assertSetEqual(get_required_event_types(parse_query("any where descendant of [process where true]")),
+                            {"any", "process"})
+
+        self.assertSetEqual(get_required_event_types(parse_query("""
+        sequence
+            [file where true]
+            [process where true]
+            [network where true]
+        """)), {"file", "process", "network"})
+
+        self.assertSetEqual(get_required_event_types(parse_query("""
+        join
+            [file where true]
+            [process where true]
+            [network where true]
+        """)), {"file", "process", "network"})
+
+        self.assertSetEqual(get_required_event_types(parse_query("""
+        file where descendant of [
+            dns where child of
+                [registry where true]]
+        """)), {"file", "dns", "registry"})
+
+        self.assertSetEqual(get_required_event_types(parse_query("""
+        sequence
+            [file where descendant of [dns where child of [registry where true]]]
+            [process where true]
+            [network where true]
+        """)), {"file", "dns", "network", "process", "registry"})
+
+    def test_uses_ancestry(self):
+        """Test that ancestry checks are detected."""
+        self.assertFalse(uses_ancestry(parse_query("any where true")))
+        self.assertTrue(uses_ancestry(parse_query("any where child of [any where true]")))
+        self.assertTrue(uses_ancestry(parse_query("any where descendant of [any where true]")))
+        self.assertTrue(uses_ancestry(parse_query("any where event of [any where true]")))
+
+        self.assertFalse(uses_ancestry(parse_query("sequence [process where true] [network where true]")))
+        self.assertTrue(uses_ancestry(parse_query("""
+        sequence
+            [process where child of [file where true]]
+            [network where true]
+        """)))
+        self.assertTrue(uses_ancestry(parse_query("""
+        join
+            [process where event of [file where true]]
+            [network where true]
+        """)))
+        self.assertTrue(uses_ancestry(parse_query("""
+        join
+            [process where descendant of [file where true]]
+            [network where true]
+        """)))
 
     def test_output_types(self):
         """Test that output types are correctly returned from eql.utils.get_output_types."""


### PR DESCRIPTION
## Issues
None

## Details
Added a few utility functions. One use case was categorizing and building stats on our existing analytics to get a sense of how often each feature is used. This can help us get a sense of our expectations for EQL in Elasticsearch.