### PR TITLE
Make string inequalities case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ _Released 2020-##-##_
 * Changed default behavior to require explicit booleans for `and`, `or` and `not`
 * (Internal) Changed the type system to use TypeHint/TypeFoldCheck/NodeInfo instead of tuples
 * Treat wildcards the same on the left and right side of `==` or `!=`
-
+* Made `<`, `<=`, `>=`, `>` perform case-insensitive string comparisons
 
 ## Version 0.8.8
 _Released 2020-04-24_

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -788,11 +788,11 @@ class Not(Expression):
 
     def demorgans(self):
         """Apply DeMorgan's law."""
-        if isinstance(self, Or):
-            return And([~ t for t in self.terms]).optimize()
+        if isinstance(self.term, Or):
+            return And([(~ t).optimize() for t in self.term.terms]).optimize()
 
-        elif isinstance(self, And):
-            return Or([~ t for t in self.terms]).optimize()
+        elif isinstance(self.term, And):
+            return Or([(~ t).optimize() for t in self.term.terms]).optimize()
 
         else:
             return ~ self.term.optimize()

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -1180,7 +1180,7 @@ class PreProcessor(ParserConfig):
 
             def _walk_field(self, node, *args, **kwargs):
                 if node.base in self.preprocessor.constants and not node.path:
-                        return self.preprocessor.constants[node.base].value
+                    return self.preprocessor.constants[node.base].value
                 return self._walk_base_node(node, *args, **kwargs)
 
             def _walk_function_call(self, node, *args, **kwargs):

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -447,8 +447,9 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         get_left = self.convert(node.left)
         get_right = self.convert(node.right)
 
-        # perform string-insensitive checks for == and !=
-        if node.comparator in (Comparison.EQ, Comparison.NE):
+        # if left and right could be strings, then we should normalize case
+        possible_string_types = FunctionCall, String, Field
+        if isinstance(node.left, possible_string_types) and isinstance(node.right, possible_string_types):
             compare = self.check_types(self.lowercase(node.function, always=False))
         else:
             compare = self.check_types(node.function)

--- a/eql/etc/test_folding.toml
+++ b/eql/etc/test_folding.toml
@@ -188,8 +188,7 @@ description = "Fold string comparisons"
     expression = '"Foo" == "Foo"'
     expected = true
 
-
-    [[string_case_sensitive_match_comparison.fold.tests]]
+    [[string_case_match_comparison.fold.tests]]
     expression = '"Foo" != "Foo"'
     expected = false
 
@@ -213,18 +212,50 @@ description = "Fold string comparisons"
 description = "Fold string comparisons"
 case_sensitive = true
 
-   [[string_case_sensitive_match_comparison.fold.tests]]
-   expression = '"Foo" == "foo"'
-   expected = false
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"Foo" == "foo"'
+    expected = false
 
-   [[string_case_sensitive_match_comparison.fold.tests]]
-   expression = '"Foo" != "foo"'
-   expected = true
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"Foo" != "foo"'
+    expected = true
 
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"Foo" < "foo"'
+    expected = true
+
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"Foo" <= "foo"'
+    expected = true
+
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"Foo" >= "foo"'
+    expected = false
+
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"Foo" > "foo"'
+    expected = false
+
+    # now flip the order and check
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"foo" < "Foo"'
+    expected = false
+
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"foo" <= "Foo"'
+    expected = false
+
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"foo" >= "Foo"'
+    expected = true
+
+    [[string_case_sensitive_match_comparison.fold.tests]]
+    expression = '"foo" > "Foo"'
+    expected = true
 
 [string_case_insensitive_match_comparison]
 description = "Fold string comparisons"
-case_sensitive = false
+case_insensitive = true
 
     [[string_case_insensitive_match_comparison.fold.tests]]
     expression = '"Foo" == "Bar"'
@@ -242,6 +273,38 @@ case_sensitive = false
     expression = '"Foo" != "foo"'
     expected = false
 
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"Foo" < "foo"'
+    expected = false
+
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"Foo" <= "foo"'
+    expected = true
+
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"Foo" >= "foo"'
+    expected = true
+
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"Foo" > "foo"'
+    expected = false
+
+    # now flip the order and check
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"foo" < "Foo"'
+    expected = false
+
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"foo" <= "Foo"'
+    expected = true
+
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"foo" >= "Foo"'
+    expected = true
+
+    [[string_case_insensitive_match_comparison.fold.tests]]
+    expression = '"foo" > "Foo"'
+    expected = false
 
 [arithmetic_comparison]
 description = "Fold arithmetic expressions cast as booleans"
@@ -257,7 +320,6 @@ description = "Fold arithmetic expressions cast as booleans"
     [[arithmetic_comparison.fold.tests]]
     expression = '1 * 2 + 3 * 4 + 10 / 2 == 2 + 12 + 5'
     expected = true
-
 
 [in_set]
 description = "Fold constant check in set"
@@ -407,7 +469,6 @@ description = "Check that any literals compared to `null` fold as `null`."
             [[null_comparison.loop.fold.tests]]
             expression = "null != $value"
             expected = true
-
 
     [[null_comparison.loop]]
 

--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -32,14 +32,16 @@ expected_event_ids  = [4]
 tags = ["comparisons", "pipes"]
 query = '''
 process where serial_event_id <= 8 and serial_event_id > 7
-| filter serial_event_id == 8'''
+| filter serial_event_id == 8
+'''
 expected_event_ids  = [8]
 
 [[queries]]
 query = '''
 process where true
 | filter serial_event_id <= 10
-| filter serial_event_id > 6'''
+| filter serial_event_id > 6
+'''
 expected_event_ids  = [7, 8, 9, 10]
 
 [[queries]]
@@ -47,7 +49,8 @@ query = '''
 process where true
 | filter serial_event_id <= 10
 | filter serial_event_id > 6
-| head 2'''
+| head 2
+'''
 expected_event_ids  = [7, 8]
 
 [[queries]]
@@ -140,7 +143,7 @@ query = 'process where (serial_event_id<9 and serial_event_id >= 7) or (opcode =
 expected_event_ids  = [7, 8]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where process_name == "VMACTHLP.exe" and unique_pid == 12
 | filter true
@@ -155,7 +158,7 @@ process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
 | unique process_name
@@ -163,7 +166,7 @@ process where process_name in ("python.exe", "SMSS.exe", "explorer.exe")
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "Explorer.exe")
 | unique length(process_name)
@@ -178,7 +181,7 @@ process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 expected_event_ids  = [3, 48]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where process_name in ("Python.exe", "smss.exe", "explorer.exe")
 | unique process_name != "python.exe"
@@ -190,7 +193,8 @@ query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
 | head 2
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [34]
 
 [[queries]]
@@ -198,37 +202,43 @@ query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
 | tail 2
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [34]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
-| unique process_name parent_process_name'''
+| unique process_name parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
-| unique process_name, parent_process_name'''
+| unique process_name, parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("python.exe", "smss.exe")
 | head 5
-| unique process_name parent_process_name'''
+| unique process_name parent_process_name
+'''
 expected_event_ids  = [3, 48, 50, 54]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] == "EN"'''
+registry where length(bytes_written_string_list) == 2 and bytes_written_string_list[1] == "EN"
+'''
 
 [[queries]]
 query = '''
-registry where key_path == "*\\MACHINE\\SAM\\SAM\\*\\Account\\Us*ers\\00*03E9\\F"'''
+registry where key_path == "*\\MACHINE\\SAM\\SAM\\*\\Account\\Us*ers\\00*03E9\\F"
+'''
 expected_event_ids  = [79]
 
 [[queries]]
@@ -294,7 +304,8 @@ expected_event_ids  = [65, 86]
 [[queries]]
 query = '''
 file where true
-| tail 3'''
+| tail 3
+'''
 expected_event_ids  = [92, 95, 96]
 
 [[queries]]
@@ -304,14 +315,14 @@ process where opcode in (1,3) and process_name in (parent_process_name, "System"
 expected_event_ids  = [2, 50, 51]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where opcode in (1,3) and process_name in (parent_process_name, "SYSTEM")
 '''
 expected_event_ids  = [2, 50, 51]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [92, 95, 96, 91]
 query = '''
 file where true
@@ -324,21 +335,24 @@ expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5 event_subtype_full process_name'''
+| sort md5 event_subtype_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5 event_subtype_full null_field process_name'''
+| sort md5 event_subtype_full null_field process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
 | head 5
-| sort md5, event_subtype_full, null_field, process_name'''
+| sort md5, event_subtype_full, null_field, process_name
+'''
 
 [[queries]]
 expected_event_ids  = [2, 1]
@@ -346,7 +360,8 @@ query = '''
 process where true
 | head 5
 | sort md5 event_subtype_full null_field process_name
-| head 2'''
+| head 2
+'''
 
 [[queries]]
 expected_event_ids  = [1, 2, 3, 4, 5]
@@ -354,7 +369,8 @@ query = '''
 process where true
 | head 5
 | sort md5 event_subtype_full null_field process_name
-| sort serial_event_id'''
+| sort serial_event_id
+'''
 
 [[queries]]
 note = "Sequence: 1-1 match"
@@ -554,7 +570,8 @@ note = "Sequence: 1-many match with join."
 query = '''
 sequence
   [process where serial_event_id=1] by unique_pid
-  [process where true] by unique_ppid'''
+  [process where true] by unique_ppid
+'''
 expected_event_ids  = [1, 2]
 
 
@@ -608,7 +625,8 @@ sequence
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids  = [67, 68,
                        69, 70,
                        72, 73,
@@ -622,7 +640,8 @@ sequence with maxspan=1d
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids  = [67, 68,
                        69, 70,
                        72, 73,
@@ -636,7 +655,8 @@ sequence with maxspan=1h
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids  = [67, 68,
                        69, 70,
                        72, 73,
@@ -650,7 +670,8 @@ sequence with maxspan=1m
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids  = [67, 68,
                        69, 70,
                        72, 73,
@@ -664,7 +685,8 @@ sequence with maxspan=10s
    [process where opcode == 2] by process_path
    [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids  = [67, 68,
                        69, 70,
                        72, 73,
@@ -678,7 +700,8 @@ sequence with maxspan=500ms
   [process where opcode == 2] by process_path
   [file where event_subtype_full == "file_delete_event"] by file_path
 | head 4
-| tail 2'''
+| tail 2
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -702,7 +725,8 @@ query = '''
 sequence
   [file where opcode=0] by unique_pid
   [file where opcode=0] by unique_pid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [55, 61]
 
 [[queries]]
@@ -710,7 +734,8 @@ query = '''
 sequence
   [file where opcode=0] by unique_pid
   [file where opcode=0] by unique_pid
-| filter events[1].serial_event_id == 92'''
+| filter events[1].serial_event_id == 92
+'''
 expected_event_ids  = [87, 92]
 
 [[queries]]
@@ -719,7 +744,8 @@ sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=0 and file_name="*.exe"] by unique_pid
 until [process where opcode=5000] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [55, 61]
 
 [[queries]]
@@ -728,7 +754,8 @@ sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=0 and file_name="*.exe"] by unique_pid
 until [process where opcode=1] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -737,7 +764,8 @@ join
   [file where opcode=0 and file_name="*.exe"] by unique_pid
   [file where opcode=2 and file_name="*.exe"] by unique_pid
 until [process where opcode=1] by unique_ppid
-| head 1'''
+| head 1
+'''
 expected_event_ids  = [61, 59]
 
 [[queries]]
@@ -753,7 +781,8 @@ query = '''
 join by unique_pid
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
-  [file where opcode == 0 and file_name == "lsass.exe"]'''
+  [file where opcode == 0 and file_name == "lsass.exe"]
+'''
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
@@ -761,7 +790,8 @@ query = '''
 join by string(unique_pid)
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
-  [file where opcode == 0 and file_name == "lsass.exe"]'''
+  [file where opcode == 0 and file_name == "lsass.exe"]
+'''
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
@@ -770,7 +800,8 @@ join by unique_pid
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
   [file where opcode == 0 and file_name == "lsass.exe"]
-until [file where opcode == 2]'''
+until [file where opcode == 2]
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -779,7 +810,8 @@ join by string(unique_pid), unique_pid, unique_pid * 2
   [process where opcode=1]
   [file where opcode=0 and file_name="svchost.exe"]
   [file where opcode == 0 and file_name == "lsass.exe"]
-until [file where opcode == 2]'''
+until [file where opcode == 2]
+'''
 expected_event_ids = []
 
 [[queries]]
@@ -794,7 +826,8 @@ expected_event_ids  = [55, 56]
 query = '''
 join by unique_pid
   [process where opcode in (1,3) and process_name="python.exe"]
-  [file where file_name == "*.exe"]'''
+  [file where file_name == "*.exe"]
+'''
 expected_event_ids  = [54, 55]
 
 [[queries]]
@@ -816,7 +849,8 @@ expected_event_ids  = [48, 3, 50, 78]
 [[queries]]
 expected_event_ids = []
 query = '''
-process where fake_field == "*"'''
+process where fake_field == "*"
+'''
 
 [[queries]]
 # no longer valid, since this returns `null`, and `not null` is still null
@@ -825,7 +859,8 @@ process where fake_field == "*"'''
 expected_event_ids = []
 query = '''
 process where fake_field != "*"
-| head 4'''
+| head 4
+'''
 
 [[queries]]
 # no longer valid, since this returns `null`, and `not null` is still null
@@ -833,12 +868,14 @@ process where fake_field != "*"
 expected_event_ids = []
 query = '''
 process where not (fake_field == "*")
-| head 4'''
+| head 4
+'''
 
 [[queries]]
 expected_event_ids = []
 query = '''
-registry where invalid_field_name != null'''
+registry where invalid_field_name != null
+'''
 
 [[queries]]
 expected_event_ids = []
@@ -852,44 +889,51 @@ process where opcode == 1
   and process_name in ("net.exe", "net1.exe")
   and not (parent_process_name == "net.exe"
   and process_name == "net1.exe")
-  and command_line == "*group *admin*" and command_line != "* /add*"'''
+  and command_line == "*group *admin*" and command_line != "* /add*"
+  '''
 expected_event_ids  = [97]
 
 [[queries]]
 expected_event_ids  = [1, 55, 57, 63, 75304]
 query = '''
 any where true
-| unique event_type_full'''
+| unique event_type_full
+'''
 
 [[queries]]
 query = '''
 process where opcode=1 and process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+'''
 expected_event_ids  = [62, 68, 78]
 
 [[queries]]
 query = '''
 process where process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+  '''
 expected_event_ids  = [62, 64, 68, 69, 78, 80]
 
 [[queries]]
 query = '''
 process where opcode=2 and process_name in ("services.exe", "smss.exe", "lsass.exe")
-  and descendant of [process where process_name == "cmd.exe" ]'''
+  and descendant of [process where process_name == "cmd.exe" ]
+'''
 expected_event_ids  = [64, 69, 80]
 
 [[queries]]
 query = '''
 process where process_name="svchost.exe"
-  and child of [file where file_name="svchost.exe" and opcode=0]'''
+  and child of [file where file_name="svchost.exe" and opcode=0]
+'''
 expected_event_ids  = [56, 58]
 
 [[queries]]
 query = '''
 process where process_name="svchost.exe"
   and not child of [file where file_name="svchost.exe" and opcode=0]
-| head 3'''
+| head 3
+'''
 expected_event_ids  = [11, 13, 15]
 
 [[queries]]
@@ -909,24 +953,28 @@ file where child of [
       process where child of [process where process_name="*wsmprovhost.exe"]
   ]
 ]
-| tail 1'''
+| tail 1
+'''
 expected_event_ids  = [91]
 
 [[queries]]
 query = '''
 file where process_name = "python.exe"
-| unique unique_pid'''
+| unique unique_pid
+'''
 expected_event_ids  = [55, 95]
 
 [[queries]]
 query = '''
 file where event of [process where process_name = "python.exe" ]
-| unique unique_pid'''
+| unique unique_pid
+'''
 expected_event_ids  = [55, 95]
 
 [[queries]]
 query = '''
-process where process_name = "python.exe"'''
+process where process_name = "python.exe"
+'''
 expected_event_ids  = [48, 50, 51, 54, 93]
 
 [[queries]]
@@ -985,7 +1033,8 @@ sequence by user_name
   [file where opcode=2] by pid,file_path
 until
   [process where opcode == 5] by ppid,process_path
-| head 2'''
+| head 2
+'''
 expected_event_ids  = [55, 59, 61, 65]
 
 [[queries]]
@@ -1020,38 +1069,44 @@ expected_event_ids  = [54, 55, 56, 54, 61, 62, 54, 67, 68, 54, 72, 73]
 
 [[queries]]
 query = '''
-process where command_line == "*%*" '''
+process where command_line == "*%*"
+'''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 query = '''
-process where command_line == "*%*%*" '''
+process where command_line == "*%*%*"
+'''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 query = '''
-process where command_line == "%*%*" '''
+process where command_line == "%*%*"
+'''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
 expected_event_ids  = [11, 60, 63]
 query = '''
 any where process_name == "svchost.exe"
-| unique_count event_type_full process_name'''
+| unique_count event_type_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [63, 60, 11]
 query = '''
 any where process_name == "svchost.exe"
 | sort event_type_full serial_event_id
-| unique_count event_type_full process_name'''
+| unique_count event_type_full process_name
+'''
 
 [[queries]]
 expected_event_ids  = [60]
 query = '''
 any where process_name == "svchost.exe"
 | unique_count event_type_full opcode
-| filter count == 7'''
+| filter count == 7
+'''
 
 [[queries]]
 expected_event_ids  = [11]
@@ -1063,33 +1118,35 @@ any where process_name == "svchost.exe"
 
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where arrayContains(bytes_written_string_list, 'En-uS')'''
+registry where arrayContains(bytes_written_string_list, 'En-uS')
+'''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
-registry where arrayContains(bytes_written_string_list, 'En')'''
+registry where arrayContains(bytes_written_string_list, 'En')
+'''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where length(bytes_written_string_list) > 0 and bytes_written_string_list[0] == 'EN-us'
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[0] == 'EN-us'
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[1] == 'EN'
@@ -1097,21 +1154,21 @@ registry where bytes_written_string_list[1] == 'EN'
 
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayContains(bytes_written_string_list, 'en-US')
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayContains(bytes_written_string_list, 'en')
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where length(bytes_written_string_list) > 0 and bytes_written_string_list[0] == 'en-US'
@@ -1160,7 +1217,7 @@ process where matchLite(?'.*?net1\s+[localgrup]{4,15}\s+.*?', command_line)
 expected_event_ids  = [98]
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where 'net.EXE' == original_file_name
 | filter process_name="net*.exe"
@@ -1169,7 +1226,7 @@ expected_event_ids  = [97]
 note = "check that case insensitive comparisons are performed even for lhs strings."
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where process_name == original_file_name and process_name='net*.exe'
 '''
@@ -1177,7 +1234,7 @@ expected_event_ids  = [97, 98]
 note = "check that case insensitive comparisons are performed for fields."
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where original_file_name == process_name and length(original_file_name) > 0
 '''
@@ -1194,7 +1251,7 @@ description = "check built-in string functions"
 
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and startsWith(file_name, 'explorer.')
 '''
@@ -1203,7 +1260,7 @@ description = "check built-in string functions"
 
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and startsWith(file_name, 'exploRER.')
 '''
@@ -1211,7 +1268,7 @@ expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and startsWith(file_name, 'expLORER.exe')
 '''
@@ -1220,28 +1277,32 @@ description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and endsWith(file_name, 'lorer.exe')'''
+file where opcode=0 and endsWith(file_name, 'lorer.exe')
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
-file where opcode=0 and endsWith(file_name, 'loREr.exe')'''
+file where opcode=0 and endsWith(file_name, 'loREr.exe')
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
 query = '''
-file where opcode=0 and startsWith('explorer.exeaaaaaaaa', file_name)'''
+file where opcode=0 and startsWith('explorer.exeaaaaaaaa', file_name)
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
-file where opcode=0 and serial_event_id = 88 and startsWith('explorer.exeaAAAA', 'EXPLORER.exe')'''
+file where opcode=0 and serial_event_id = 88 and startsWith('explorer.exeaAAAA', 'EXPLORER.exe')
+'''
 expected_event_ids  = [88]
 description = "check built-in string functions"
 
@@ -1253,7 +1314,7 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'plore') == 2 and indexOf(file_name, '.pf') == null
 '''
@@ -1276,7 +1337,7 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'plorer.', 0) == 2
 '''
@@ -1292,7 +1353,7 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'plorer.', 2) != null
 '''
@@ -1314,7 +1375,7 @@ expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'plorer.', 2) == 2
 '''
@@ -1338,7 +1399,7 @@ expected_event_ids  = [88]
 description = "check substring ranges"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'explorer.', 0) == 0
 '''
@@ -1346,7 +1407,7 @@ expected_event_ids  = [88, 92]
 description = "check substring ranges"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where serial_event_id=88 and substring(file_name, 0, 4) == 'expl'
 '''
@@ -1362,7 +1423,7 @@ expected_event_ids  = [88, 91]
 description = "check substring ranges"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where substring(file_name, 1, 3) == 'xp'
 '''
@@ -1440,7 +1501,7 @@ expected_event_ids  = [5]
 description = "test string concatenation"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where concat(serial_event_id, ':', process_name, opcode) == '5:winINIT.exe3'
 '''
@@ -1448,7 +1509,7 @@ expected_event_ids  = [5]
 description = "test string concatenation"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 process where process_name != original_file_name and length(original_file_name) > 0
 '''
@@ -1472,7 +1533,7 @@ registry where arraySearch(bytes_written_string_list, a, a == 'EN-US')
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
@@ -1480,7 +1541,7 @@ registry where arraySearch(bytes_written_string_list, a, a == 'en-us')
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
@@ -1560,7 +1621,7 @@ network where safe(divide(process_name, process_name))
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 query = '''
 file where serial_event_id == 82 and (true == (process_name in ('svchost.EXE', 'bad.exe', 'bad2.exe')))
 '''
@@ -1568,21 +1629,21 @@ expected_event_ids  = [82]
 description = "nested set comparisons"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayCount(bytes_written_string_list, s, s == '*-us') == 1
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayCount(bytes_written_string_list, s, s == '*en*') == 2
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where arrayContains(bytes_written_string_list, "missing", "en-US")
@@ -1613,28 +1674,28 @@ expected_event_ids = [82]
 query = "file where serial_event_id % 40 == 2"
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids = [1, 2]
 query = '''
 process where between(process_name, "s", "e") == "yst"
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids = [1, 2]
 query = '''
 process where between(process_name, "s", "e", false) == "yst"
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids = []
 query = '''
 process where between(process_name, "s", "e", false, true) == "yst"
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids = [1, 2, 42]
 query = '''
 process where between(process_name, "s", "e", false, true) == "t"
@@ -1653,7 +1714,7 @@ process where between(process_name, "S", "e", true) == "ystem Idle Proc"
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids = [1]
 query = '''
 process where between(process_name, "s", "e", true) == "ystem Idle Proc"
@@ -1704,7 +1765,7 @@ process where length(between(process_name, 'g', 'e')) > 0
 '''
 
 [[queries]]
-case_sensitive = false
+case_insensitive = true
 expected_event_ids = [7, 14, 22, 29, 44]
 query = '''
 process where length(between(process_name, 'g', 'e')) > 0

--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -143,6 +143,61 @@ query = 'process where (serial_event_id<9 and serial_event_id >= 7) or (opcode =
 expected_event_ids  = [7, 8]
 
 [[queries]]
+query = 'process where process_name >= "System" and process_name <= "System Idle Process"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+query = 'process where process_name >= "System" and process_name < "System Idle Process"'
+expected_event_ids  = [2]
+
+[[queries]]
+query = 'process where process_name > "System" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+query = 'process where process_name > "System" and process_name < "System Idle Process"'
+expected_event_ids  = []
+
+[[queries]]
+query = 'process where process_name >= "Syste" and process_name <= "Systez"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+query = 'process where process_name > "System" and process_name < "Systez"'
+expected_event_ids  = [1]
+
+[[queries]]
+query = 'process where process_name >= "System Idle Process" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+case_sensitive = true
+notes = "s == 0x73; S == 0x53"
+query = 'process where process_name >= "system idle process" and process_name <= "System Idle Process"'
+expected_event_ids  = []
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "system idle process" and process_name <= "System Idle Process"'
+expected_event_ids  = [1]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "SYSTE" and process_name < "systex"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "sysT" and process_name < "SYsTeZZZ"'
+expected_event_ids  = [1, 2]
+
+[[queries]]
+case_insensitive = true
+query = 'process where process_name >= "SYSTE" and process_name <= "systex"'
+expected_event_ids  = [1, 2]
+
+
+[[queries]]
 case_insensitive = true
 query = '''
 process where process_name == "VMACTHLP.exe" and unique_pid == 12

--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -147,6 +147,17 @@ query = 'process where process_name >= "System" and process_name <= "System Idle
 expected_event_ids  = [1, 2]
 
 [[queries]]
+# test that it works for comparing field <--> field
+case_insensitive = true
+query = 'process where serial_event_id < 5 and process_name <= parent_process_name'
+expected_event_ids  = [2, 3]
+
+[[queries]]
+case_sensitive = true
+query = 'process where serial_event_id < 5 and process_name <= parent_process_name'
+expected_event_ids  = [2]
+
+[[queries]]
 query = 'process where process_name >= "System" and process_name < "System Idle Process"'
 expected_event_ids  = [2]
 

--- a/eql/etc/test_string_functions.toml
+++ b/eql/etc/test_string_functions.toml
@@ -104,7 +104,7 @@ description = "Test the `endsWith` function with case matching"
 
 [endswith_insensitive]
 description = "Test the `endsWith` function with case insensitivity"
-case_sensitive = false
+case_insensitive = true
 
     [[endswith_insensitive.fold.tests]]
     expression = "endsWith('FooBarBaz', 'baz')"
@@ -497,7 +497,7 @@ description = "Test that `wildcard` folds with correct case matches."
 
 [wildcard_case_insensitive]
 description = "Test that `wildcard` function folds case insensitive as expected."
-case_sensitive = false
+case_insensitive = true
 
     [[wildcard_case_insensitive.fold.tests]]
     expression = 'wildcard("FOO", "f*o*o*")'

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -66,7 +66,12 @@ def load_tests():
         data = eql.load_dump(eql.etc.get_etc_path(name))
 
         for test_name, contents in sorted(data.items()):
-            case_sensitive = contents.get("case_sensitive")
+            case_sensitive = None
+
+            if "case_sensitive" in contents:
+                case_sensitive = contents["case_sensitive"]
+            elif "case_insensitive" in contents:
+                case_sensitive = not contents["case_insensitive"]
 
             extract_tests(test_name, contents, case_sensitive=case_sensitive)
 


### PR DESCRIPTION
## Issues
Closes #30

## Details
Made all string comparisons always insensitive. Removed the exception of `<`, `<=`, `>=`, `>` which were previously case-sensitive. I added some query folding unit tests tests and some system tests as well.

In #28, I had a tri-state `case_sensitive` field which was null | true | false. That seemed like a bad idea, so instead now there's two separate flags; `case_sensitive`  and `case_insensitive`. Any test that has a flag should only be tested with that configuration (this repo has no case-sensitive support). For tests without that flag, they should be applied to both and should be written with the  exact case to match. Then they can work for both.