### PR TITLE
Remove case_sensitive parameter for between

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Version 0.9.1
-_Released 2020-05-26_
+_Released 2020-05-27_
 
 ### Removed
 * `case_sensitive` parameter to `between`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Version 0.9.1
-_Released 2020-05-27_
+_Released 2020-05-28_
 
 ### Removed
 * `case_sensitive` parameter to `between`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.1
+_Released 2020-05-26_
+
+### Removed
+* `case_sensitive` parameter to `between`
+
+
 ## Version 0.9.0
-_Released 2020-##-##_
+_Released 2020-05-18_
 
 ### Added
 * Support for escaped identifiers in fields using \`backtick\` syntax

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,8 @@ SPHINXBUILD ?= $(VENV_BIN)/sphinx-build
 $(VENV):
 	pip install virtualenv
 	virtualenv $(VENV)
-	$(PIP) install -q -r requirements.txt
 	$(PIP) install setuptools -U
+	$(PIP) setup.py install
 
 
 .PHONY: clean
@@ -24,7 +24,7 @@ clean:
 
 .PHONY: testdeps
 testdeps:
-	$(PIP) install -r requirements_test.txt
+	$(PIP) install eql[test]
 
 .PHONY: pytest
 pytest: $(VENV) testdeps

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If Python is configured and already in the PATH, then ``eql`` will be readily av
 
 ```console
 $ eql --version
-eql 0.8
+eql 0.9
 ```
 
 From there, try a [sample json file](docs/_static/example.json) and test it with EQL.

--- a/docs/query-guide/functions.rst
+++ b/docs/query-guide/functions.rst
@@ -61,23 +61,26 @@ math, string manipulation or more sophisticated expressions to be expressed.
         arraySearch(my_array, item, item.props[1].level == 4)                  // returns false
         arraySearch(my_array, item, arraySearch(item.props, p, p.level == 2))  // returns true
 
-.. function:: between(source, left, right [, greedy=false, case_sensitive=false])
+.. function:: between(source, left, right [, greedy=false])
 
     Extracts a substring from ``source`` that's also between ``left`` and ``right``.
 
     :param greedy: Matches the longest string when set, similar to ``.*`` vs ``.*?``.
-    :param case_sensitive: Match case when searching for ``left`` and ``right```.
+
+    .. versionchanged:: 0.9.1
+        Removed ``case_sensitive`` parameter
 
     .. code-block:: eql
 
         between("welcome to event query language", " ", " ")            // returns "to"
         between("welcome to event query language", " ", " ", true)      // returns "to event query"
 
+
 .. function:: cidrMatch(ip_address, cidr_block [, ...])
 
     Returns ``true`` if the source address matches any of the provided CIDR blocks.
 
-    .. versionchanged:: 0.8
+    .. versionadded:: 0.8
 
     .. code-block:: eql
 

--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -1753,25 +1753,14 @@ query = '''
 process where between(process_name, "s", "e", false) == "yst"
 '''
 
-[[queries]]
-case_insensitive = true
-expected_event_ids = []
-query = '''
-process where between(process_name, "s", "e", false, true) == "yst"
-'''
 
 [[queries]]
-case_insensitive = true
+case_sensitive = true
 expected_event_ids = [1, 2, 42]
 query = '''
-process where between(process_name, "s", "e", false, true) == "t"
+process where between(process_name, "s", "e", false) == "t"
 '''
 
-[[queries]]
-expected_event_ids = [1, 2]
-query = '''
-process where between(process_name, "S", "e", false, true) == "yst"
-'''
 
 [[queries]]
 expected_event_ids = [1]

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -145,21 +145,18 @@ class Between(FunctionSignature):
     """Return a substring that's between two other substrings."""
 
     name = "between"
-    argument_types = [TypeHint.String, TypeHint.String, TypeHint.String, TypeHint.Boolean, TypeHint.Boolean]
+    argument_types = [TypeHint.String, TypeHint.String, TypeHint.String, TypeHint.Boolean]
     minimum_args = 3
     return_value = TypeHint.String
     sometimes_null = True
 
     @classmethod
-    def run(cls, source_string, first, second, greedy=False, case_sensitive=False):
+    def run(cls, source_string, first, second, greedy=False):
         """Return the substring between two other ones."""
         if is_string(source_string) and is_string(first) and is_string(second):
-            match_string = source_string
-
-            if not case_sensitive:
-                match_string = match_string.lower()
-                first = first.lower()
-                second = second.lower()
+            match_string = source_string.lower()
+            first = first.lower()
+            second = second.lower()
 
             try:
                 start_pos = match_string.index(first) + len(first)


### PR DESCRIPTION
### Issues
Related to https://github.com/elastic/elasticsearch/issues/56749

### Details
Removed the `case_sensitive` parameter to `between`. We identified the inconsistency as part of the Elasticsearch testing, and decided that EQL shouldn't be quasi-case-sensitive or quasi-case-insensitive. Instead, this Python EQL library will always be case insensitive. This is similar to #30.


