### PR TITLE
Fixed invalid list indexing for UniqueCountPipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.2
+_Released 2020-05-29_
+
+### Fixed
+* Removed invalid index into empty array for `UniqueCountPipe.output_schemas` with custom walkers
+
+
 ## Version 0.9.1
 _Released 2020-05-28_
 

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.1'
+__version__ = '0.9.2'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/pipes.py
+++ b/eql/pipes.py
@@ -125,6 +125,9 @@ class UniqueCountPipe(ByPipe):
     def output_schemas(cls, arguments, event_schemas):
         # type: (list, list[Schema]) -> list[Schema]
         """Generate the output schema and determine the ``key`` field dyanmically."""
+        if len(event_schemas) < 1:
+            return event_schemas
+
         event_schemas = list(event_schemas)
         first_event_type, = event_schemas[0].schema.keys()
 


### PR DESCRIPTION
## Issues
Related to https://github.com/endgameinc/eqllib/issues/32

## Details
Check the array length before indexing. The error isn't exactly in EQL proper, but custom walkers can accidentally trigger this if they don't invoke the pipes the same way, as we see in the related eqllib issue.