### PR TITLE
Make case_sensitive/case_insensitive test settings explicit

### DIFF
--- a/eql/ast.py
+++ b/eql/ast.py
@@ -10,7 +10,7 @@ from enum import Enum
 from .errors import EqlError
 from .signatures import SignatureMixin
 from .types import TypeHint, NodeInfo  # noqa: F401
-from .utils import to_unicode, is_string, is_number, ParserConfig
+from .utils import to_unicode, is_string, is_number, ParserConfig, fold_case
 
 __all__ = (
     # base classes
@@ -660,7 +660,7 @@ class InSet(Expression):
                 continue
             k = literal.value
             if isinstance(literal, String):
-                values.setdefault(k.lower(), literal)
+                values.setdefault(fold_case(k), literal)
             else:
                 values[k] = literal
         return values

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -11,7 +11,7 @@ from .pipes import *  # noqa: F403
 from .transpilers import BaseEngine, BaseTranspiler
 from .events import Event, AnalyticOutput
 from .schema import EVENT_TYPE_ANY, EVENT_TYPE_GENERIC
-from .utils import is_string, is_array, is_number, get_type_converter
+from .utils import is_string, is_array, is_number, get_type_converter, fold_case
 
 PIPE_EOF = object()
 
@@ -155,7 +155,7 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         @functools.wraps(f)
         def decorated(a, b):
             if is_string(a) and is_string(b):
-                return f(a.lower(), b.lower())
+                return f(fold_case(a), fold_case(b))
 
             if not always:
                 return f(a, b)
@@ -195,7 +195,7 @@ class PythonEngine(BaseEngine, BaseTranspiler):
     @classmethod
     def _remove_case(cls, key):
         if is_string(key):
-            return key.lower()
+            return fold_case(key)
         elif is_array(key):
             return tuple(cls._remove_case(k) for k in key)
         else:
@@ -414,10 +414,7 @@ class PythonEngine(BaseEngine, BaseTranspiler):
             values = set()
             for item in node.container:
                 value = item.value
-                if is_string(value):
-                    values.add(value.lower())
-                else:
-                    values.add(value)
+                values.add(fold_case(value))
 
             get_value = self.convert(node.expression)
 
@@ -426,9 +423,7 @@ class PythonEngine(BaseEngine, BaseTranspiler):
                 if check_value is None:
                     return
 
-                if is_string(check_value):
-                    check_value = check_value.lower()
-                return check_value in values
+                return fold_case(check_value) in values
 
             return callback
 

--- a/eql/etc/test_folding.toml
+++ b/eql/etc/test_folding.toml
@@ -1,5 +1,7 @@
 [arithmetic]
 description = "Test that math integer and float operations fold as expected."
+case_sensitive = true
+case_insensitive = true
 
     [[arithmetic.fold.tests]]
     expression = "7 + 3"
@@ -72,6 +74,8 @@ description = "Test that math integer and float operations fold as expected."
 
 [integer_comparison]
 description = "Check that numeric comparisons are folded."
+case_sensitive = true
+case_insensitive = true
 
     [[integer_comparison.fold.tests]]
     expression = "-3 < 4"
@@ -99,6 +103,8 @@ description = "Check that numeric comparisons are folded."
 
 [float_comparison]
 description = "Check that numeric comparisons are folded."
+case_sensitive = true
+case_insensitive = true
 
     [[float_comparison.fold.tests]]
     expression = "3.0 < 4.0"
@@ -127,6 +133,8 @@ description = "Check that numeric comparisons are folded."
 
 [int_float_comparison]
 description = "Check that numeric comparisons are folded."
+case_sensitive = true
+case_insensitive = true
 
     [[int_float_comparison.fold.tests]]
     expression = "-3 < 4.0"
@@ -155,6 +163,8 @@ description = "Check that numeric comparisons are folded."
 
 [float_int_comparison]
 description = "Check that numeric comparisons are folded."
+case_sensitive = true
+case_insensitive = true
 
     [[float_int_comparison.fold.tests]]
     expression = "3.0 < 4"
@@ -183,6 +193,8 @@ description = "Check that numeric comparisons are folded."
 
 [string_case_match_comparison]
 description = "Fold string comparisons"
+case_sensitive = true
+case_insensitive = true
 
     [[string_case_match_comparison.fold.tests]]
     expression = '"Foo" == "Foo"'
@@ -307,7 +319,9 @@ case_insensitive = true
     expected = false
 
 [arithmetic_comparison]
-description = "Fold arithmetic expressions cast as booleans"
+description = "Fold comparisons of arithmetic expressions"
+case_sensitive = true
+case_insensitive = true
 
     [[arithmetic_comparison.fold.tests]]
     expression = '(1 * 2 + 3 * 4 + 10 / 2) == 19'
@@ -323,6 +337,8 @@ description = "Fold arithmetic expressions cast as booleans"
 
 [in_set]
 description = "Fold constant check in set"
+case_sensitive = true
+case_insensitive = true
 
     [[in_set.fold.tests]]
     expression = "345 in (123, 345)"
@@ -348,8 +364,39 @@ description = "Fold constant check in set"
     expression = "'foo' in ('bar', 'baz')"
     expected = false
 
+    [[in_set.fold.tests]]
+    expression = "'Foo' in ('Foo', 'Bar', 'Baz')"
+    expected = true
+
+    [[in_set.fold.tests]]
+    expression = "'Foo' not in ('Foo', 'Bar', 'Baz')"
+    expected = false
+
+
+[in_set_case_sensitive]
+description = "Fold string in set with mismatching cases"
+case_sensitive = true
+
+    [[in_set_case_sensitive.fold.tests]]
+    expression = "'foo' in ('Foo', 'Bar', 'Baz')"
+    expected = false
+
+
+[in_set_case_insensitive]
+description = "Fold string in insensitive sest"
+case_insensitive = true
+
+    [[in_set_case_insensitive.fold.tests]]
+    expression = "'foo' in ('Foo', 'Bar', 'Baz')"
+    expected = true
+
+
+
+
 [or]
 description = "Check that three-value boolean logic works for `or`."
+case_sensitive = true
+case_insensitive = true
 
     [[or.fold.tests]]
     expression = "true or false"
@@ -386,6 +433,8 @@ description = "Check that three-value boolean logic works for `or`."
 
 [and]
 description = "Check that three-value boolean logic works for `and`."
+case_sensitive = true
+case_insensitive = true
 
     [[and.fold.tests]]
     expression = "true and false"
@@ -422,6 +471,8 @@ description = "Check that three-value boolean logic works for `and`."
 
 [not]
 description = "Check that `not` negates `null` as null`"
+case_sensitive = true
+case_insensitive = true
 
     [[not.fold.tests]]
     expression = "not null"
@@ -438,6 +489,8 @@ description = "Check that `not` negates `null` as null`"
 
 [null_comparison]
 description = "Check that any literals compared to `null` fold as `null`."
+case_sensitive = true
+case_insensitive = true
 
     [[null_comparison.fold.tests]]
     expression = "null == null"
@@ -511,6 +564,8 @@ description = "Check that any literals compared to `null` fold as `null`."
 
 [complex]
 description = "Test recurisve folding for more complex expressions."
+case_sensitive = true
+case_insensitive = true
 
     [[complex.fold.tests]]
     expression = '(100 * 10) - ("hello":length())'

--- a/eql/etc/test_optimizer.toml
+++ b/eql/etc/test_optimizer.toml
@@ -1,5 +1,7 @@
 [or]
 description = "Test that `or false` and `or true` are optimized correctly"
+case_insensitive = true
+case_sensitive = true
 
     [[or.optimizer.tests]]
     expression = "a == 1 or true"
@@ -27,6 +29,8 @@ description = "Test that `or false` and `or true` are optimized correctly"
 
 [and]
 description = "Test that `and false` and `and true` are optimized correctly"
+case_insensitive = true
+case_sensitive = true
 
     [[and.optimizer.tests]]
     expression = "a == 1 and true"
@@ -74,6 +78,8 @@ description = "Test that `and false` and `and true` are optimized correctly"
 
 [wildcard_syntax]
 description = 'Test that `x == "*"` converts to a wildcard function.'
+case_insensitive = true
+case_sensitive = true
 
     [[wildcard_syntax.equivalent.tests]]
     expression = 'field == "a*b*c"'

--- a/eql/etc/test_queries.toml
+++ b/eql/etc/test_queries.toml
@@ -1,34 +1,50 @@
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where serial_event_id = 1'
 expected_event_ids  = [1]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where serial_event_id < 4'
 expected_event_ids  = [1, 2, 3]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where true | head 6'
 expected_event_ids  = [1, 2, 3, 4, 5, 6]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where false'
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 query = 'process where missing_field != null'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [1, 2, 3, 4, 5]
 query = 'process where bad_field == null | head 5'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name == "impossible name" or (serial_event_id < 4.5 and serial_event_id >= 3.1)
 '''
 expected_event_ids  = [4]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 tags = ["comparisons", "pipes"]
 query = '''
 process where serial_event_id <= 8 and serial_event_id > 7
@@ -37,6 +53,8 @@ process where serial_event_id <= 8 and serial_event_id > 7
 expected_event_ids  = [8]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where true
 | filter serial_event_id <= 10
@@ -45,6 +63,8 @@ process where true
 expected_event_ids  = [7, 8, 9, 10]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where true
 | filter serial_event_id <= 10
@@ -54,6 +74,8 @@ process where true
 expected_event_ids  = [7, 8]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where true
 | head 1000
@@ -64,42 +86,58 @@ process where true
 expected_event_ids  = [9, 10]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where serial_event_id<=8 and serial_event_id > 7
 '''
 expected_event_ids  = [8]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code >= 0'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where 0 <= exit_code'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code <= 0'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code < 1'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where exit_code > -1'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [58, 64, 69, 74, 80, 85, 90, 93, 94, 75303]
 query = 'process where -1 < exit_code'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids = []
 query = '''
@@ -109,40 +147,58 @@ process where null == (exit_code > -1)
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [1, 2, 3, 4, 5, 6, 7]
 query = 'process where null == (exit_code > -1) | head 7'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "check that comparisons against null values return null"
 expected_event_ids  = [1, 2, 3, 4, 5, 6, 7]
 query = 'process where null == (-1 < exit_code) | head 7'
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where exit_code > 0'
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where exit_code < 0'
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where 0 < exit_code'
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where 0 > exit_code'
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where (serial_event_id<=8 and serial_event_id > 7) and (opcode=3 and opcode>2)'
 expected_event_ids  = [8]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where (serial_event_id<9 and serial_event_id >= 7) or (opcode == pid)'
 expected_event_ids  = [7, 8]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name >= "System" and process_name <= "System Idle Process"'
 expected_event_ids  = [1, 2]
 
@@ -158,26 +214,38 @@ query = 'process where serial_event_id < 5 and process_name <= parent_process_na
 expected_event_ids  = [2]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name >= "System" and process_name < "System Idle Process"'
 expected_event_ids  = [2]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name > "System" and process_name <= "System Idle Process"'
 expected_event_ids  = [1]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name > "System" and process_name < "System Idle Process"'
 expected_event_ids  = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name >= "Syste" and process_name <= "Systez"'
 expected_event_ids  = [1, 2]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name > "System" and process_name < "Systez"'
 expected_event_ids  = [1]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where process_name >= "System Idle Process" and process_name <= "System Idle Process"'
 expected_event_ids  = [1]
 
@@ -217,6 +285,8 @@ process where process_name == "VMACTHLP.exe" and unique_pid == 12
 expected_event_ids  = [12]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
@@ -240,6 +310,8 @@ process where process_name in ("python.exe", "smss.exe", "Explorer.exe")
 expected_event_ids  = [3, 34, 48]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique length(process_name) == length("python.exe")
@@ -255,6 +327,8 @@ process where process_name in ("Python.exe", "smss.exe", "explorer.exe")
 expected_event_ids  = [3, 48]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
@@ -264,6 +338,8 @@ process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 expected_event_ids  = [34]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 | unique process_name
@@ -273,6 +349,8 @@ process where process_name in ("python.exe", "smss.exe", "explorer.exe")
 expected_event_ids  = [34]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe")
 | unique process_name parent_process_name
@@ -280,6 +358,8 @@ process where process_name in ("python.exe", "smss.exe")
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe")
 | unique process_name, parent_process_name
@@ -287,6 +367,8 @@ process where process_name in ("python.exe", "smss.exe")
 expected_event_ids  = [3, 48, 50, 54, 78]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("python.exe", "smss.exe")
 | head 5
@@ -302,18 +384,24 @@ registry where length(bytes_written_string_list) == 2 and bytes_written_string_l
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 registry where key_path == "*\\MACHINE\\SAM\\SAM\\*\\Account\\Us*ers\\00*03E9\\F"
 '''
 expected_event_ids  = [79]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_path == "*\\red_ttp\\wininit.*" and opcode in (0,1,2,3,4)
 '''
 expected_event_ids  = [84, 85]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where file_name == "csrss.exe" and opcode=0
   and descendant of [process where opcode in (1,3) and process_name="cmd.exe"]
@@ -321,6 +409,8 @@ file where file_name == "csrss.exe" and opcode=0
 expected_event_ids  = [72]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where opcode=1 and process_name == "csrss.exe"
   and descendant of [file where file_name == "csrss.exe" and opcode=0]
@@ -328,6 +418,8 @@ process where opcode=1 and process_name == "csrss.exe"
 expected_event_ids  = [73]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where opcode=1 and process_name == "smss.exe"
   and descendant of [
@@ -340,6 +432,8 @@ process where opcode=1 and process_name == "smss.exe"
 expected_event_ids  = [78]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where file_path="*\\red_ttp\\winin*.*"
   and opcode in (0,1,2) and user_name="vagrant"
@@ -347,6 +441,8 @@ file where file_path="*\\red_ttp\\winin*.*"
 expected_event_ids  = [83, 86]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where file_path="*\\red_ttp\\winin*.*"
   and opcode not in (0,1,2) and user_name="vagrant"
@@ -354,6 +450,8 @@ file where file_path="*\\red_ttp\\winin*.*"
 expected_event_ids  = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where file_path="*\\red_ttp\\winin*.*"
   and opcode not in (3, 4, 5, 6 ,7) and user_name="vagrant"
@@ -362,12 +460,16 @@ expected_event_ids  = [83, 86]
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where file_name in ("wininit.exe", "lsass.exe") and opcode == 2
 '''
 expected_event_ids  = [65, 86]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where true
 | tail 3
@@ -375,6 +477,8 @@ file where true
 expected_event_ids  = [92, 95, 96]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where opcode in (1,3) and process_name in (parent_process_name, "System")
 '''
@@ -397,6 +501,8 @@ file where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
@@ -405,6 +511,8 @@ process where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
@@ -413,6 +521,8 @@ process where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [2, 1, 4, 3, 5]
 query = '''
 process where true
@@ -421,6 +531,8 @@ process where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [2, 1]
 query = '''
 process where true
@@ -430,6 +542,8 @@ process where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [1, 2, 3, 4, 5]
 query = '''
 process where true
@@ -439,6 +553,8 @@ process where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: 1-1 match"
 query = '''
 sequence
@@ -448,6 +564,8 @@ sequence
 expected_event_ids  = [1, 2]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: many-1 match."
 query = '''
 sequence
@@ -457,6 +575,8 @@ sequence
 expected_event_ids  = [4, 5]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: 1-1-1."
 query = '''
 sequence
@@ -468,6 +588,8 @@ expected_event_ids  = [1, 2, 3]
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: 1-many-many."
 query = '''
 sequence
@@ -478,6 +600,8 @@ sequence
 expected_event_ids  = [1, 2, 3]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where serial_event_id <= 3]
@@ -488,6 +612,8 @@ expected_event_ids = [1, 2, 3,
                       2, 3, 4,
                       3, 4, 5]
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]
@@ -497,6 +623,8 @@ sequence
 expected_event_ids = [1, 2, 3,
                       2, 3, 4]
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]
@@ -506,6 +634,8 @@ sequence
 expected_event_ids  = [1, 2, 3]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where serial_event_id <= 4]
@@ -519,6 +649,8 @@ expected_event_ids  = [1, 2, 3, 4,
                        4, 5, 6, 7]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]
@@ -531,6 +663,8 @@ expected_event_ids  = [1, 2, 3, 4,
                        3, 4, 5, 6]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]
@@ -542,6 +676,8 @@ expected_event_ids  = [1, 2, 3, 4,
                        2, 3, 4, 5]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]
@@ -552,6 +688,8 @@ sequence
 expected_event_ids  = [1, 2, 3, 4]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]        by unique_pid
@@ -563,6 +701,8 @@ expected_event_ids  = [48, 53,
                        97, 98]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true]        by unique_pid,  process_path
@@ -574,6 +714,8 @@ expected_event_ids  = [48, 53,
                        97, 98]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where opcode == 1] by unique_pid
@@ -586,6 +728,8 @@ until
 expected_event_ids  = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where opcode == 1] by unique_pid
@@ -598,6 +742,8 @@ until
 expected_event_ids  = [54, 55, 61, 67]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where opcode == 1] by unique_pid
@@ -609,6 +755,8 @@ expected_event_ids  = [54, 55, 61, 67]
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where opcode == 1] by unique_pid,  process_path
@@ -620,6 +768,8 @@ expected_event_ids  = [54, 55, 61, 67]
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where opcode == 1] by unique_pid,  process_path
@@ -632,6 +782,8 @@ until
 expected_event_ids  = [54, 55, 61, 67]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: 1-many match with join."
 query = '''
 sequence
@@ -642,6 +794,8 @@ expected_event_ids  = [1, 2]
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: many-many match with join."
 query = '''
 sequence
@@ -652,6 +806,8 @@ expected_event_ids  = [1, 2, 2, 3]
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: non-field based join."
 query = '''
 sequence
@@ -663,6 +819,8 @@ expected_event_ids  = [1, 2,
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 note = "Sequence: multiple non-field based joins."
 query = '''
 sequence
@@ -674,6 +832,8 @@ expected_event_ids  = [1, 2,
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by unique_pid
   [process where opcode=1 and process_name == 'MSBuild.exe']
@@ -684,6 +844,8 @@ description = "test that process sequences are working correctly"
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where event_subtype_full == "file_create_event"] by file_path
@@ -699,6 +861,8 @@ expected_event_ids  = [67, 68,
                        74, 75]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence with maxspan=1d
   [file where event_subtype_full == "file_create_event"] by file_path
@@ -714,6 +878,8 @@ expected_event_ids  = [67, 68,
                        74, 75]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence with maxspan=1h
   [file where event_subtype_full == "file_create_event"] by file_path
@@ -729,6 +895,8 @@ expected_event_ids  = [67, 68,
                        74, 75]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence with maxspan=1m
   [file where event_subtype_full == "file_create_event"] by file_path
@@ -744,6 +912,8 @@ expected_event_ids  = [67, 68,
                        74, 75]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence with maxspan=10s
    [file where event_subtype_full == "file_create_event"] by file_path
@@ -759,6 +929,8 @@ expected_event_ids  = [67, 68,
                        74, 75]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence with maxspan=500ms
   [file where event_subtype_full == "file_create_event"] by file_path
@@ -771,6 +943,8 @@ sequence with maxspan=500ms
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where serial_event_id < 5]
@@ -779,6 +953,8 @@ sequence
 expected_event_ids  = [1, 2, 2, 3, 3, 4]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where opcode=0 and file_name="svchost.exe"] by unique_pid
@@ -787,6 +963,8 @@ sequence
 expected_event_ids  = [55, 56]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where opcode=0] by unique_pid
@@ -796,6 +974,8 @@ sequence
 expected_event_ids  = [55, 61]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where opcode=0] by unique_pid
@@ -805,6 +985,8 @@ sequence
 expected_event_ids  = [87, 92]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
@@ -815,6 +997,8 @@ until [process where opcode=5000] by unique_ppid
 expected_event_ids  = [55, 61]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where opcode=0 and file_name="*.exe"] by unique_pid
@@ -825,6 +1009,8 @@ until [process where opcode=1] by unique_ppid
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join
   [file where opcode=0 and file_name="*.exe"] by unique_pid
@@ -835,6 +1021,8 @@ until [process where opcode=1] by unique_ppid
 expected_event_ids  = [61, 59]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by user_name
   [process where opcode in (1,3) and process_name="smss.exe"]
@@ -843,6 +1031,8 @@ join by user_name
 expected_event_ids  = [78, 48]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by unique_pid
   [process where opcode=1]
@@ -852,6 +1042,8 @@ join by unique_pid
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by string(unique_pid)
   [process where opcode=1]
@@ -861,6 +1053,8 @@ join by string(unique_pid)
 expected_event_ids  = [54, 55, 61]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by unique_pid
   [process where opcode=1]
@@ -871,6 +1065,8 @@ until [file where opcode == 2]
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by string(unique_pid), unique_pid, unique_pid * 2
   [process where opcode=1]
@@ -881,6 +1077,8 @@ until [file where opcode == 2]
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join
   [file where opcode=0 and file_name="svchost.exe"] by unique_pid
@@ -889,6 +1087,8 @@ join
 expected_event_ids  = [55, 56]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by unique_pid
   [process where opcode in (1,3) and process_name="python.exe"]
@@ -897,6 +1097,8 @@ join by unique_pid
 expected_event_ids  = [54, 55]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by user_name
   [process where opcode in (1,3) and process_name="python.exe"]
@@ -905,6 +1107,8 @@ join by user_name
 expected_event_ids  = [48, 78]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join
   [process where opcode in (1,3) and process_name="python.exe"]
@@ -913,43 +1117,55 @@ join
 expected_event_ids  = [48, 3, 50, 78]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 query = '''
 process where fake_field == "*"
 '''
 
 [[queries]]
-# no longer valid, since this returns `null`, and `not null` is still null
-# expected_event_ids  = [1, 2, 3, 4]
-
-expected_event_ids = []
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where fake_field != "*"
 | head 4
 '''
-
-[[queries]]
 # no longer valid, since this returns `null`, and `not null` is still null
 # expected_event_ids  = [1, 2, 3, 4]
 expected_event_ids = []
+
+
+[[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where not (fake_field == "*")
 | head 4
 '''
+# no longer valid, since this returns `null`, and `not null` is still null
+# expected_event_ids  = [1, 2, 3, 4]
+expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 query = '''
 registry where invalid_field_name != null
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 query = '''
 registry where length(bad_field) > 0
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where opcode == 1
   and process_name in ("net.exe", "net1.exe")
@@ -960,6 +1176,8 @@ process where opcode == 1
 expected_event_ids  = [97]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [1, 55, 57, 63, 75304]
 query = '''
 any where true
@@ -967,6 +1185,8 @@ any where true
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where opcode=1 and process_name in ("services.exe", "smss.exe", "lsass.exe")
   and descendant of [process where process_name == "cmd.exe" ]
@@ -974,6 +1194,8 @@ process where opcode=1 and process_name in ("services.exe", "smss.exe", "lsass.e
 expected_event_ids  = [62, 68, 78]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name in ("services.exe", "smss.exe", "lsass.exe")
   and descendant of [process where process_name == "cmd.exe" ]
@@ -981,6 +1203,8 @@ process where process_name in ("services.exe", "smss.exe", "lsass.exe")
 expected_event_ids  = [62, 64, 68, 69, 78, 80]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where opcode=2 and process_name in ("services.exe", "smss.exe", "lsass.exe")
   and descendant of [process where process_name == "cmd.exe" ]
@@ -988,6 +1212,8 @@ process where opcode=2 and process_name in ("services.exe", "smss.exe", "lsass.e
 expected_event_ids  = [64, 69, 80]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name="svchost.exe"
   and child of [file where file_name="svchost.exe" and opcode=0]
@@ -995,6 +1221,8 @@ process where process_name="svchost.exe"
 expected_event_ids  = [56, 58]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name="svchost.exe"
   and not child of [file where file_name="svchost.exe" and opcode=0]
@@ -1003,6 +1231,8 @@ process where process_name="svchost.exe"
 expected_event_ids  = [11, 13, 15]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name="lsass.exe"
   and child of [
@@ -1013,6 +1243,8 @@ process where process_name="lsass.exe"
 expected_event_ids  = [62, 64]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where child of [
   process where child of [
@@ -1024,6 +1256,8 @@ file where child of [
 expected_event_ids  = [91]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where process_name = "python.exe"
 | unique unique_pid
@@ -1031,6 +1265,8 @@ file where process_name = "python.exe"
 expected_event_ids  = [55, 95]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where event of [process where process_name = "python.exe" ]
 | unique unique_pid
@@ -1038,16 +1274,22 @@ file where event of [process where process_name = "python.exe" ]
 expected_event_ids  = [55, 95]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where process_name = "python.exe"
 '''
 expected_event_ids  = [48, 50, 51, 54, 93]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = 'process where event of [process where process_name = "python.exe" ]'
 expected_event_ids  = [48, 50, 51, 54, 93]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [file where file_name="lsass.exe"] by file_path,process_path
@@ -1056,6 +1298,8 @@ sequence
 expected_event_ids  = [61, 62]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by user_name
   [file where file_name="lsass.exe"] by file_path, process_path
@@ -1064,6 +1308,8 @@ sequence by user_name
 expected_event_ids  = [61, 62]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by pid
   [file where file_name="lsass.exe"] by file_path,process_path
@@ -1072,6 +1318,8 @@ sequence by pid
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by user_name
   [file where opcode=0] by file_path
@@ -1083,6 +1331,8 @@ sequence by user_name
 expected_event_ids  = [88, 89, 90, 91]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by user_name
   [file where opcode=0] by pid,file_path
@@ -1093,6 +1343,8 @@ until
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by user_name
   [file where opcode=0] by pid,file_path
@@ -1104,6 +1356,8 @@ until
 expected_event_ids  = [55, 59, 61, 65]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence by pid
   [file where opcode=0] by file_path
@@ -1115,6 +1369,8 @@ sequence by pid
 expected_event_ids = []
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 join by user_name
   [file where true] by pid,file_path
@@ -1124,6 +1380,8 @@ join by user_name
 expected_event_ids  = [55, 56, 59, 58]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 sequence
   [process where true] by unique_pid
@@ -1134,24 +1392,32 @@ sequence
 expected_event_ids  = [54, 55, 56, 54, 61, 62, 54, 67, 68, 54, 72, 73]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where command_line == "*%*"
 '''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where command_line == "*%*%*"
 '''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where command_line == "%*%*"
 '''
 expected_event_ids  = [4, 6, 28]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [11, 60, 63]
 query = '''
 any where process_name == "svchost.exe"
@@ -1159,6 +1425,8 @@ any where process_name == "svchost.exe"
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [63, 60, 11]
 query = '''
 any where process_name == "svchost.exe"
@@ -1167,6 +1435,8 @@ any where process_name == "svchost.exe"
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [60]
 query = '''
 any where process_name == "svchost.exe"
@@ -1175,6 +1445,8 @@ any where process_name == "svchost.exe"
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [11]
 query = '''
 any where process_name == "svchost.exe"
@@ -1241,42 +1513,56 @@ registry where length(bytes_written_string_list) > 0 and bytes_written_string_li
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[0] == 'en-US'
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [57]
 query = '''
 registry where bytes_written_string_list[1] == 'en'
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where matchLite(command_line, ?'.*?net1\s+localgroup\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where matchLite(command_line, ?'.*?net1\s+\w+\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where matchLite(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 expected_event_ids  = [98]
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [98]
 query = '''
 process where match(command_line, ?'.*?net1\s+\w{4,15}\s+.*?')
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where matchLite(command_line, ?'.*?net1\s+[localgrup]{4,15}\s+.*?')
 '''
@@ -1342,6 +1628,8 @@ expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where opcode=0 and endsWith(file_name, 'lorer.exe')
 '''
@@ -1358,6 +1646,8 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where opcode=0 and startsWith('explorer.exeaaaaaaaa', file_name)
 '''
@@ -1373,6 +1663,8 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where opcode=0 and stringContains('ABCDEFGHIexplorer.exeJKLMNOP', file_name)
 '''
@@ -1388,6 +1680,8 @@ expected_event_ids  = [88]
 description = "check built-in string functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'explorer.') > 0 and indexOf(file_name, 'plore', 100) > 0
 '''
@@ -1427,6 +1721,8 @@ expected_event_ids  = [88, 92]
 description = "check built-in string functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'plorer.', 4) != null
 '''
@@ -1434,6 +1730,8 @@ expected_event_ids = []
 description = "check built-in string functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where opcode=0 and indexOf(file_name, 'thing that never happened') != null
 '''
@@ -1497,6 +1795,8 @@ expected_event_ids  = [88, 91, 92]
 description = "check substring ranges"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where substring(file_name, -4) == '.exe'
 '''
@@ -1504,6 +1804,8 @@ expected_event_ids  = [55, 59, 61, 65, 67, 70, 72, 75, 76, 81, 83, 86, 88, 91]
 description = "check substring ranges"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 file where substring(file_name, -4, -1) == '.ex'
 '''
@@ -1511,6 +1813,8 @@ expected_event_ids  = [55, 59, 61, 65, 67, 70, 72, 75, 76, 81, 83, 86, 88, 91]
 description = "check substring ranges"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where add(serial_event_id, 0) == 1 and add(0, 1) == serial_event_id
 '''
@@ -1518,6 +1822,8 @@ expected_event_ids  = [1]
 description = "test built-in math functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where subtract(serial_event_id, -5) == 6
 '''
@@ -1525,6 +1831,8 @@ expected_event_ids  = [1]
 description = "test built-in math functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where multiply(6, serial_event_id) == 30 and divide(30, 4.0) == 7.5
 '''
@@ -1532,6 +1840,8 @@ expected_event_ids  = [5]
 description = "test built-in math functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where modulo(11, add(serial_event_id, 1)) == serial_event_id
 '''
@@ -1539,6 +1849,8 @@ expected_event_ids  = [1, 2, 3, 5, 11]
 description = "test built-in math functions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where serial_event_id == number('5')
 '''
@@ -1546,6 +1858,8 @@ expected_event_ids  = [5]
 description = "test string/number conversions"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [50]
 description = "test string/number conversions"
 query = '''
@@ -1553,6 +1867,8 @@ process where serial_event_id == number('0x32', 16)
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [50]
 description = "test string/number conversions"
 query = '''
@@ -1560,6 +1876,8 @@ process where serial_event_id == number('32', 16)
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 query = '''
 process where concat(serial_event_id, ':', process_name, opcode) == '5:wininit.exe3'
 '''
@@ -1584,6 +1902,8 @@ description = "check that case insensitive comparisons are performed for fields.
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [57]
 description = "test arraySearch functionality for lists of strings, and lists of objects"
 query = '''
@@ -1615,6 +1935,8 @@ registry where arraySearch(bytes_written_string_list, a, endsWith(a, '-us'))
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - true"
 query = '''
@@ -1623,6 +1945,8 @@ network where mysterious_field
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 description = "test arraySearch - false"
 query = '''
@@ -1630,6 +1954,8 @@ network where mysterious_field and arraySearch(mysterious_field.subarray, s, fal
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - conditional"
 query = '''
@@ -1637,6 +1963,8 @@ network where mysterious_field and arraySearch(mysterious_field.subarray, s, s.a
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - conditional"
 query = '''
@@ -1644,6 +1972,8 @@ network where mysterious_field and arraySearch(mysterious_field.subarray, s, s.a
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - nested"
 query = '''
@@ -1653,6 +1983,8 @@ network where mysterious_field
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - nested with cross-check pass"
 query = '''
@@ -1662,6 +1994,8 @@ network where mysterious_field
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - nested with cross-check pass"
 query = '''
@@ -1671,6 +2005,8 @@ network where mysterious_field
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids  = [75305]
 description = "test arraySearch - nested with cross-check pass"
 query = '''
@@ -1680,6 +2016,8 @@ network where mysterious_field
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 description = "test 'safe()' wrapper for exception handling"
 query = '''
@@ -1716,26 +2054,38 @@ registry where arrayContains(bytes_written_string_list, "missing", "en-US")
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [82]
 query = "file where serial_event_id - 1 == 81"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [82]
 query = "file where serial_event_id + 1 == 83"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [82]
 query = "file where serial_event_id * 2 == 164"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [82, 83]
 query = "file where serial_event_id / 2 == 41"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [82]
 query = "file where serial_event_id / 2.0 == 41"
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [82]
 query = "file where serial_event_id % 40 == 2"
 
@@ -1753,7 +2103,6 @@ query = '''
 process where between(process_name, "s", "e", false) == "yst"
 '''
 
-
 [[queries]]
 case_sensitive = true
 expected_event_ids = [1, 2, 42]
@@ -1761,8 +2110,9 @@ query = '''
 process where between(process_name, "s", "e", false) == "t"
 '''
 
-
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [1]
 query = '''
 process where between(process_name, "S", "e", true) == "ystem Idle Proc"
@@ -1776,12 +2126,16 @@ process where between(process_name, "s", "e", true) == "ystem Idle Proc"
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [95]
 query = '''
 file where between(file_path, "dev", ".json", false) == "\\TestLogs\\something"
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [95]
 query = '''
 file where between(file_path, "dev", ".json", true) == "\\TestLogs\\something"
@@ -1789,24 +2143,32 @@ file where between(file_path, "dev", ".json", true) == "\\TestLogs\\something"
 
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [75304, 75305]
 query = '''
 network where cidrMatch(source_address, "10.6.48.157/8")
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 query = '''
 network where cidrMatch(source_address, "192.168.0.0/16")
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [75304, 75305]
 query = '''
 network where cidrMatch(source_address, "192.168.0.0/16", "10.6.48.157/8")
 
 '''
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = [75304, 75305]
 query = '''
 network where cidrMatch(source_address, "0.0.0.0/0")
@@ -1827,6 +2189,8 @@ process where length(between(process_name, 'g', 'e')) > 0
 '''
 
 [[queries]]
+case_sensitive = true
+case_insensitive = true
 expected_event_ids = []
 query = '''
 process where length(between(process_name, 'g', 'z')) > 0

--- a/eql/etc/test_string_functions.toml
+++ b/eql/etc/test_string_functions.toml
@@ -1,5 +1,7 @@
 [between]
 description = "Test the proper evaluation of the `between` function"
+case_sensitive = true
+case_insensitive = true
 
     [[between.fold.tests]]
     expression = 'between("welcome to the planet", null, "planet")'
@@ -60,6 +62,8 @@ description = "Test the proper evaluation of the `between` function"
 
 [concat]
 description = "Test the `concat` function"
+case_sensitive = true
+case_insensitive = true
 
     [[concat.fold.tests]]
     expression = 'concat(null)'
@@ -92,6 +96,8 @@ description = "Test the `concat` function"
 
 [endswith]
 description = "Test the `endsWith` function with case matching"
+case_sensitive = true
+case_insensitive = true
 
     [[endswith.fold.tests]]
     expression = "endsWith('FooBarBaz', 'Baz')"
@@ -122,6 +128,8 @@ case_sensitive = true
 
 [indexof]
 description = "Test `indexOf()` with exact case specified"
+case_sensitive = true
+case_insensitive = true
 
     [[indexof.fold.tests]]
     expression = 'indexOf(null, "L")'
@@ -170,6 +178,8 @@ description = "Test `indexOf()` with exact case specified"
 
 [length]
 description = "Test the folding of the `length` function."
+case_sensitive = true
+case_insensitive = true
 
     [[length.fold.tests]]
     expression = 'length(null)'
@@ -186,6 +196,8 @@ description = "Test the folding of the `length` function."
 
 [match]
 description = "Test the `match` function"
+case_sensitive = true
+case_insensitive = true
 
     [match.verifier]
 
@@ -227,6 +239,8 @@ description = "Test the `match` function"
 
 [number]
 description = "Test the `number` function"
+case_sensitive = true
+case_insensitive = true
 
     [number.verifier]
 
@@ -289,6 +303,8 @@ description = "Test the `number` function"
 
 [startswith]
 description = "Test the `startsWith` function"
+case_sensitive = true
+case_insensitive = true
 
     [startswith.verifier]
         [[startswith.verifier.failures]]
@@ -344,6 +360,7 @@ case_sensitive = true
 
 [startswith_case_insensitive]
 description = "Test the `startsWith` function with case-insensitive matching"
+case_insensitive = true
 
     [[startswith_case_insensitive.fold.tests]]
     expression = "startsWith('FooBar', 'Foo')"
@@ -364,6 +381,8 @@ description = "Test the `startsWith` function with case-insensitive matching"
 
 [string]
 description = "Test the `string` function"
+case_sensitive = true
+case_insensitive = true
 
     [[string.fold.tests]]
     expression = "string(null)"
@@ -387,6 +406,8 @@ description = "Test the `string` function"
 
 [substring]
 description = "Test the `substring` function when the case already matches"
+case_sensitive = true
+case_insensitive = true
 
     [[substring.fold.tests]]
     expression = "substring(null, 5)"
@@ -450,6 +471,8 @@ description = "Test the `substring` function when the case already matches"
 
 [wildcard]
 description = "Test that `wildcard` folds with correct case matches."
+case_sensitive = true
+case_insensitive = true
 
     [[wildcard.fold.tests]]
     expression = 'wildcard(null, "f*o*o*")'

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -626,7 +626,7 @@ class ToString(FunctionSignature):
     def run(cls, source):
         """"Convert a value to a string."""
         if source is not None:
-            if source is True or source is False:
+            if isinstance(source, bool):
                 return "true" if source else "false"
 
             return to_unicode(source)

--- a/eql/optimizer.py
+++ b/eql/optimizer.py
@@ -1,6 +1,6 @@
 """Optimizer for the EQL syntax tree."""
 from .functions import get_function
-from .utils import is_string
+from .utils import fold_case
 from .walkers import Walker, DepthFirstWalker
 
 __all__ = (
@@ -66,13 +66,8 @@ class Optimizer(DepthFirstWalker):
             if lhs is None or rhs is None:
                 return Null()
 
-            # Check that the types match first
-            if not isinstance(node.right, type(node.left)):
-                return Boolean(node.comparator == Comparison.NE)
-
-            if isinstance(node.left, String):
-                lhs = lhs.lower()
-                rhs = rhs.lower()
+            lhs = fold_case(lhs)
+            rhs = fold_case(rhs)
 
             return Boolean(node.function(lhs, rhs))
 
@@ -107,9 +102,8 @@ class Optimizer(DepthFirstWalker):
 
         # check to see if a literal value is in the list of literal values
         if isinstance(node.expression, Literal):
-            value = node.expression.value
-            if is_string(value):
-                value = value.lower()
+            value = fold_case(node.expression.value)
+
             if value in node.get_literals():
                 return Boolean(True)
             container = dynamic

--- a/eql/tests/base.py
+++ b/eql/tests/base.py
@@ -59,13 +59,22 @@ class TestEngine(unittest.TestCase):
         with open(cls.queries_file, "r") as f:
             queries = []
             for q in toml.load(f)["queries"]:
-                is_case_sensitive = q.get("case_sensitive")
-                analytic = cls.get_analytic(q['query'], is_case_sensitive)
-                analytic.metadata['_info'] = q.copy()
-                q['analytic'] = analytic
+                case_settings = []
+                if q.get("case_sensitive") is True:
+                    case_settings.append(True)
 
-                if is_case_sensitive in (None, match_case_sensitive):
-                    queries.append(q)
+                if q.get("case_insensitive") is True:
+                    case_settings.append(False)
+
+                assert len(case_settings) > 0, q
+
+                for cs in case_settings:
+                    analytic = cls.get_analytic(q['query'], cs)
+                    analytic.metadata['_info'] = q.copy()
+                    q['analytic'] = analytic
+
+                    if cs == match_case_sensitive:
+                        queries.append(q)
 
             return list(filter(cls.filter_queries, queries))
 

--- a/eql/utils.py
+++ b/eql/utils.py
@@ -8,6 +8,7 @@ import sys
 import threading
 
 PLUGIN_PREFIX = "eql_"
+CASE_INSENSITIVE = True
 _loaded_plugins = False
 
 # Python2 and Python3 compatible type checking
@@ -52,6 +53,18 @@ def is_number(n):
 def is_array(a):
     """Check if a number is array-like."""
     return isinstance(a, (list, tuple))
+
+
+def is_insensitive():
+    """Check if insensitivity is enabled."""
+    return CASE_INSENSITIVE
+
+
+def fold_case(s):
+    """Helper function for normalizing case for strings."""
+    if is_insensitive() and is_string(s):
+        return s.lower()
+    return s
 
 
 def str_presenter(dumper, data):

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -38,8 +38,6 @@ def extract_tests(test_name, contents, case_settings, **params):
         expression = parametrize(fold_test["expression"])
         expected = fold_test.get("expected", None)
 
-        assert len(case_settings) > 0, test_name
-
         for case_sensitive in case_settings:
             fold_tests.append((test_name, expression, expected, case_sensitive))
 
@@ -81,6 +79,8 @@ def load_tests():
 
             if contents.get("case_insensitive") is True:
                 case_settings.append(False)
+
+            assert len(case_settings) > 0, "{test} is missing case_sensitive/case_insensitive".format(test=test_name)
 
             extract_tests(test_name, contents, case_settings)
 

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -94,12 +94,12 @@ def engine_eval(expr):
 
 
 @contextlib.contextmanager
-def case_sensitivity(value: bool):
+def case_sensitivity(enabled):
     """Helper function for toggling case sensitivity."""
     prev = eql.utils.CASE_INSENSITIVE
 
     try:
-        eql.utils.CASE_INSENSITIVE = not value
+        eql.utils.CASE_INSENSITIVE = not enabled
         yield
     finally:
         eql.utils.CASE_INSENSITIVE = prev


### PR DESCRIPTION
## Issues
Closes #34

## Details
The implicit behavior of `case_sensitive` and `case_insensitive` was understandably leading to confusion within Elasticsearch. I updated the TOML tests to make these configurations explicit. For any test, you have to specify if it supports a case sensitive configuration and a case insensitive configuration. Unprovided values aka `null` will default to `false`.