### PR TITLE
Fix bug when a macro returns a field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 _Released 2020-07-27_
 
 ### Fixed
-* Bug with preprocessor expansion when using a schema
+* Uncaught exception when macros return a field
 
 
 ## Version 0.9.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.4
+_Released 2020-07-27_
+
+### Fixed
+* Bug with preprocessor expansion when using a schema
+
+
 ## Version 0.9.3
 _Released 2020-07-07_
 

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -719,7 +719,7 @@ class LarkToEQL(Interpreter):
             type_hint = TypeHint.Unknown
 
             if ast_node.base not in self._var_types:
-                ast_node, type_hint = self._update_field_info(node, ast_node)
+                type_hint = self._update_field_info(NodeInfo(ast_node, source=node)).type_info
 
         elif isinstance(ast_node, ast.FunctionCall):
             signature = self._function_lookup.get(ast_node.name)

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -235,7 +235,7 @@ class TestPreProcessor(unittest.TestCase):
         macro SELF(a) a
         """)
 
-        with Schema({"foo": {"bar": "number"}}), preprocessor:
+        with preprocessor:
             parse_query("foo where SELF(bar) == 1")
 
             with self.assertRaises(EqlSemanticError):

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -7,6 +7,7 @@ from eql.ast import *  # noqa: F403
 from eql.parser import *  # noqa: F403
 from eql.transpilers import TextEngine
 from eql.errors import EqlTypeMismatchError
+from eql.schema import Schema
 
 
 class TestPreProcessor(unittest.TestCase):
@@ -230,11 +231,9 @@ class TestPreProcessor(unittest.TestCase):
 
     def test_macro_expansion_hinting_bug(self):
         """Test bugfix for macro expansion."""
-        preprocessor = get_preprocessor("""
-        macro SELF(a) a
-        """)
+        preprocessor = get_preprocessor("macro SELF(a)   a")
 
-        with preprocessor:
+        with Schema({"foo": {"bar": "number"}}), preprocessor:
             parse_query("foo where SELF(bar) == 1")
 
             with self.assertRaises(EqlTypeMismatchError):

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -6,7 +6,8 @@ from collections import OrderedDict
 from eql.ast import *  # noqa: F403
 from eql.parser import *  # noqa: F403
 from eql.transpilers import TextEngine
-from eql import EqlTypeMismatchError
+from eql.errors import EqlSemanticError
+from eql import EqlTypeMismatchError, Schema
 
 
 class TestPreProcessor(unittest.TestCase):
@@ -227,3 +228,15 @@ class TestPreProcessor(unittest.TestCase):
                 before = parse_expression(before)
             after = parse_expression(after)
             self.assertEqual(pp2.expand(before), after)
+
+    def test_macro_expansion_hinting_bug(self):
+        """Test bugfix for macro expansion."""
+        preprocessor = get_preprocessor("""
+        macro SELF(a) a
+        """)
+
+        with Schema({"foo": {"bar": "number"}}), preprocessor:
+            parse_query("foo where SELF(bar) == 1")
+
+            with self.assertRaises(EqlSemanticError):
+                parse_query("foo where SELF(bar) == 'baz'")

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -7,7 +7,6 @@ from eql.ast import *  # noqa: F403
 from eql.parser import *  # noqa: F403
 from eql.transpilers import TextEngine
 from eql.errors import EqlSemanticError
-from eql import EqlTypeMismatchError, Schema
 
 
 class TestPreProcessor(unittest.TestCase):
@@ -238,5 +237,5 @@ class TestPreProcessor(unittest.TestCase):
         with preprocessor:
             parse_query("foo where SELF(bar) == 1")
 
-            with self.assertRaises(EqlSemanticError):
+            with self.assertRaises(EqlTypeMismatchError):
                 parse_query("foo where SELF(bar) == 'baz'")

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 from eql.ast import *  # noqa: F403
 from eql.parser import *  # noqa: F403
 from eql.transpilers import TextEngine
-from eql.errors import EqlSemanticError
+from eql.errors import EqlTypeMismatchError
 
 
 class TestPreProcessor(unittest.TestCase):


### PR DESCRIPTION
## Issues
Closes #36

## Details
Fixed a bug that was introduced with #16. When a macro expanded to a field, there was an uncaught exception at https://github.com/endgameinc/eql/blob/c76c36afe2afa35729dc5b352f97a6f2180e31ad/eql/parser.py#L721-L722. The line just needed to be updated to account for NodeInfo and the current type tracking.