### PR TITLE
DOCS: Document the changes for EQL in Elasticsearch

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - ``=`` can no longer be substituted for the ``==`` operator.
    - ``?"`` and ``?'`` no longer indicate raw strings. Use the ``"""..."""`` syntax instead.
    
-   For more details, see the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>` section of the Elasticsearch EQL documentation.
+   For more details, see the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the Elasticsearch EQL documentation.
 
 Getting Started
 ^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,8 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - All operators and functions are case-sensitive. For example, ``process_name == "cmd.exe"`` is different from ``process_name == "Cmd.exe"``.
    - Use ``:`` to perform case-insensitive equals. For example, ``process_name : "cmd.exe"`` is identical to ``process_name : "Cmd.exe"``.
    - The ``==`` and ``!=`` operators no longer expand wildcard characters. ``process_name == "cmd*.exe"`` will interpret``*`` as a literal asterisk, not a wildcard character.
-   - `=` can no longer be substituted for `==`
+   - ``==`` can no longer be substitutde for ``=``
+   - ``?"`` and ``?'`` are not used for raw strings. Instead, use the new ``"""..."""`` syntax
    - For case-sensitive wildcard matching, use the ``wildcard`` function
    
    For more details, browse the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the EQL documentation in Elasticsearch.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,7 +36,7 @@ If Python is configured and already in the PATH, then ``eql`` will be readily av
 .. code-block:: console
 
      $ eql --version
-     eql 0.8
+     eql 0.9
 
 From there, try a :download:`sample json file <_static/example.json>` and test it with EQL.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
 
 
 .. note::
-   This documentation is about EQL for Endgame. Several syntax changes were made to `bring Event Query Language to Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html>`_:
+   This documentation is about EQL for Elastic Endgame. Several syntax changes were made to `bring Event Query Language to the Elastic Stack <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html>`_:
    
    - All operators and functions are case-sensitive. For example, ``process_name == "cmd.exe"`` is different from ``process_name == "Cmd.exe"``.
    - Use ``:`` to perform case-insensitive equals. For example, ``process_name : "cmd.exe"`` is identical to ``process_name : "Cmd.exe"``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    
    - All operators and functions are case-sensitive. For example, ``process_name == "cmd.exe"`` is different from ``process_name == "Cmd.exe"``.
    - Use ``:`` to perform case-insensitive equals. For example, ``process_name : "cmd.exe"`` is identical to ``process_name : "Cmd.exe"``.
-   - The ``==`` and ``!=`` operators no longer expand wildcard characters. ``process_name == "cmd*.exe"`` will interpret``*`` as a literal asterisk, not a wildcard character.
+   - The ``==`` and ``!=`` operators no longer expand wildcard characters. ``process_name == "cmd*.exe"`` will interpret ``*`` as a literal asterisk, not a wildcard character.
    - ``==`` can no longer be substitutde for ``=``
    - ``?"`` and ``?'`` are not used for raw strings. Instead, use the new ``"""..."""`` syntax
    - For case-sensitive wildcard matching, use the ``wildcard`` function

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - All operators and functions are case-sensitive. For example, ``process_name == "cmd.exe"`` is different from ``process_name == "Cmd.exe"``.
    - Use ``:`` to perform case-insensitive equals. For example, ``process_name : "cmd.exe"`` is identical to ``process_name : "Cmd.exe"``.
    - The ``==`` and ``!=`` operators no longer expand wildcard characters. ``process_name == "cmd*.exe"`` will interpret``*`` as a literal asterisk, not a wildcard character.
+   - `=` can no longer be substituted for `==`
    - For case-sensitive wildcard matching, use the ``wildcard`` function
    
    For more details, browse the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the EQL documentation in Elasticsearch.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,17 @@ It supports field lookups, boolean logic, comparisons, wildcard matching, and fu
 EQL also has a preprocessor that can perform parse and translation time evaluation, allowing for easily sharable components between queries.
 
 
+.. note::
+   This documentation is about EQL for Endgame. Several syntax changes were made to `bring Event Query Language to Elasticsearch <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html>`_:
+   
+   - All operators and functions are case-sensitive. For example, ``process_name == "cmd.exe"`` is different from ``process_name == "Cmd.exe"``.
+   - Use ``:`` to perform case-insensitive equals. For example, ``process_name : "cmd.exe"`` is identical to ``process_name : "Cmd.exe"``.
+   - The ``==`` and ``!=`` operators no longer expand wildcard characters. ``process_name == "cmd*.exe"`` will interpret``*`` as a literal asterisk, not a wildcard character.
+   - For case-sensitive wildcard matching, use the ``wildcard`` function
+   
+   For more details, browse the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the EQL documentation in Elasticsearch.
+   
+
 .. image:: _static/eql-whoami.jpg
     :alt: what is EQL
     :scale: 50%

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,12 +22,6 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - For case-sensitive wildcard matching, use the ``wildcard`` function
    
    For more details, browse the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the EQL documentation in Elasticsearch.
-   
-
-.. image:: _static/eql-whoami.jpg
-    :alt: what is EQL
-    :scale: 50%
-
 
 Getting Started
 ^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,14 +15,13 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
 .. note::
    This documentation is about EQL for Elastic Endgame. Several syntax changes were made to `bring Event Query Language to the Elastic Stack <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html>`_:
    
-   - All operators and functions are case-sensitive. For example, ``process_name == "cmd.exe"`` is different from ``process_name == "Cmd.exe"``.
-   - Use ``:`` to perform case-insensitive equals. For example, ``process_name : "cmd.exe"`` is identical to ``process_name : "Cmd.exe"``.
-   - The ``==`` and ``!=`` operators no longer expand wildcard characters. ``process_name == "cmd*.exe"`` will interpret ``*`` as a literal asterisk, not a wildcard character.
-   - ``==`` can no longer be substitutde for ``=``
-   - ``?"`` and ``?'`` are not used for raw strings. Instead, use the new ``"""..."""`` syntax
-   - For case-sensitive wildcard matching, use the ``wildcard`` function
+   - Most operators and functions are now case-sensitive. For example, ``process_name == "cmd.exe"`` is no longer equivalent to ``process_name == "Cmd.exe"``.
+   - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.
+   - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard. For case-sensitive wildcard matching, use the ``wildcard`` function.
+   - ``=`` can no longer be substituted for the ``==`` operator.
+   - ``?"`` and ``?'`` no longer indicate raw strings. Use the ``"""..."""`` syntax instead.
    
-   For more details, browse the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the EQL documentation in Elasticsearch.
+   For more details, see the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>` section of the Elasticsearch EQL documentation.
 
 Getting Started
 ^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.
    - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard. For case-sensitive wildcard matching, use the ``wildcard`` function.
    - ``=`` can no longer be substituted for the ``==`` operator.
+   - ``'`` strings are no longer supported. Use `"""` or `"` to represent strings.
    - ``?"`` and ``?'`` no longer indicate raw strings. Use the ``"""..."""`` syntax instead.
    
    For more details, see the `limitations <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-limitations>`_ section of the Elasticsearch EQL documentation.


### PR DESCRIPTION
## Issues
None

## Details
Added a `note` section in the documents to acknowledge these changes for EQL in Elasticsearch:
* the new `:` operator
* the changed semantics for  `==` and `!=` with respect to wildcards
* the case-sensitive nature of EQL

Preview is available [here](https://eql.readthedocs.io/en/docs-elasticsearch-note/index.html)

cc @jrodewig @paulewing