### PR TITLE
Add toggle for Elasticsearch-style syntax

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        python -m pip install wheel
     - name: Lint with flake8
       run: |
         python setup.py -q lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.4
+_Released 2020-07-27_
+
+### Fixed
+* Uncaught exception when macros return a field
+
+
 ## Version 0.9.3
 _Released 2020-07-07_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.5
+_Released TBD_
+
+### Added
+* Toggle to parse with Elasticsearch syntax
+
+### Changed
+* Parser rule for method syntax. No whitespace is allowed between the `:` and opening `(`
+
+
 ## Version 0.9.4
 _Released 2020-07-27_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.3
+_Released 2020-07-07_
+
+### Added
+* Internal toggle to turn off case insensitivity
+* Additional tests to handle case sensitive and insensitive modes
+
+
 ## Version 0.9.2
 _Released 2020-05-29_
 

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.3'
+__version__ = '0.9.4'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -56,7 +56,7 @@ named_subquery.2: name "of" subquery
 
 // hacky approach to work around this ambiguity introduced with the colon operator
 // x : length
-// x : length( )
+// x : length( ) not allowed, now requires `:length(` form
 METHOD_START.3: ":" NAME "("
 method_name: METHOD_START
 method: method_name [expressions] ")"

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -719,7 +719,7 @@ class LarkToEQL(Interpreter):
             type_hint = TypeHint.Unknown
 
             if ast_node.base not in self._var_types:
-                ast_node, type_hint = self._update_field_info(node, ast_node)
+                type_hint = self._update_field_info(NodeInfo(ast_node, source=node)).type_info
 
         elif isinstance(ast_node, ast.FunctionCall):
             signature = self._function_lookup.get(ast_node.name)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with io.open('eql/__init__.py', 'rt', encoding='utf8') as f:
     __version__ = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 install_requires = [
-    "lark-parser~=0.8.5",
+    "lark-parser~=0.10.1",
     "enum34; python_version<'3.4'",
 ]
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -535,4 +535,3 @@ class TestParser(unittest.TestCase):
 
             self.assertRaises(EqlSyntaxError, parse_query, 'process where process_name == """cmd.exe"""')
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name : \"cmd.exe\"")
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -520,6 +520,10 @@ class TestParser(unittest.TestCase):
             parse_query('process where process_name : """cmd.exe"""')
             parse_query('process where process_name : """""cmd.exe"""""')
 
+            # parser interprets this similar to:              process where process_name == length()
+            # so it will have an error, because length() has no arguments
+            self.assertRaises(EqlSemanticError, parse_query, "process where process_name :  length()")
+
             self.assertRaises(EqlSemanticError, parse_query, "process where pid : 1")
 
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name = \"cmd.exe\"")
@@ -532,6 +536,10 @@ class TestParser(unittest.TestCase):
             parse_query("process where process_name == 'cmd.exe'")
             parse_query("process where process_name == ?'cmd.exe'")
             parse_query("process where process_name == ?\"cmd.exe\"")
+
+            # parser interprets this similar to:              process where process_name == length()
+            # so it will have an error, because length() has no arguments
+            self.assertRaises(EqlSemanticError, parse_query, "process where process_name :  length()")
 
             self.assertRaises(EqlSyntaxError, parse_query, 'process where process_name == """cmd.exe"""')
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name : \"cmd.exe\"")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -6,11 +6,12 @@ import sys
 import traceback
 import unittest
 
+from eql import Schema
 from eql.ast import *  # noqa: F403
 from eql.errors import EqlSyntaxError, EqlSemanticError, EqlParseError
 from eql.parser import (
     parse_query, parse_expression, parse_definitions, ignore_missing_functions, parse_field, parse_literal,
-    extract_query_terms, keywords
+    extract_query_terms, keywords, elasticsearch_syntax
 )
 from eql.walkers import DepthFirstWalker
 from eql.pipes import *   # noqa: F403
@@ -509,3 +510,29 @@ class TestParser(unittest.TestCase):
         # simple query with pipes
         simple_extracted = extract_query_terms(network_event + "| unique process_name, user_name\n\n| tail 10")
         self.assertListEqual(simple_extracted, [network_event.strip()])
+
+    def test_elasticsearch_flag_enabled(self):
+        """Check that removed Endgame syntax throws an error and new syntax does not."""
+        schema = Schema({"process": {"process_name": "string",  "pid": "number"}})
+
+        with elasticsearch_syntax, schema:
+            parse_query('process where process_name : "cmd.exe"')
+            parse_query('process where process_name : """cmd.exe"""')
+            parse_query('process where process_name : """""cmd.exe"""""')
+
+            self.assertRaises(EqlSemanticError, parse_query, "process where pid : 1")
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name = \"cmd.exe\"")
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == 'cmd.exe'")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == ?'cmd.exe'")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == ?\"cmd.exe\"")
+
+        with schema:
+            parse_query("process where process_name == 'cmd.exe'")
+            parse_query("process where process_name == ?'cmd.exe'")
+            parse_query("process where process_name == ?\"cmd.exe\"")
+
+            self.assertRaises(EqlSyntaxError, parse_query, 'process where process_name == """cmd.exe"""')
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name : \"cmd.exe\"")
+


### PR DESCRIPTION
## Issues
Closes #40

## Details
Added conditional support for Elasticsearch syntax. You can't mix and match between Endgame and Elasticsearch parsing.

I had to muck around with the grammar to keep method support, because we're using LALR(1), which only has a look ahead of 1. That wasn't enough to resolve the ambiguity `<expression> : <expression>` and `<expression> : <method name> ( ... )`, because that would require a lookahead of two, or differently structured rules. So now, there is no whitespace allowed between `:` the name of the method and the open parenthesis. `:length()` is valid, but `: length()` is not valid and `:length ()` is not either. But you can still have space before the colon for methods.