### PR TITLE
Extend attributes for fields passed into macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Version 0.9.7
+_Released 2020-11-30_
+
+### Added
+* Support for extending attributes within macros
 
 ## Version 0.9.6
 _Released 2020-11-24_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Version 0.9.7
-_Released 2020-11-30_
+_Released 2020-12-01_
 
 ### Added
 * Support for extending attributes within macros

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.6'
+__version__ = '0.9.7'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -1152,7 +1152,7 @@ class Macro(BaseMacro, EqlNode):
                 argument_value = lookup[node.base]
                 if node.path:
                     if not isinstance(argument_value, Field):
-                        raise EqlCompileError("Unable to expand {} on non-field type {}".format(argument_value, node.base))
+                        raise EqlCompileError("Invalid expansion: {} ({}={})".format(node, node.base, argument_value))
 
                     # extend the attributes being retrieved
                     return Field(argument_value.base, list(argument_value.path) + list(node.path))

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -1152,7 +1152,7 @@ class Macro(BaseMacro, EqlNode):
                 argument_value = lookup[node.base]
                 if node.path:
                     if not isinstance(argument_value, Field):
-                        raise EqlCompileError("Unable to expand macro {} on non-field type".format(argument_value))
+                        raise EqlCompileError("Unable to expand {} on non-field type {}".format(argument_value, node.base))
 
                     # extend the attributes being retrieved
                     return Field(argument_value.base, list(argument_value.path) + list(node.path))

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -1149,12 +1149,15 @@ class Macro(BaseMacro, EqlNode):
         def _walk_field(node):
             # type: (Field) -> Field
             if node.base in lookup:
-                argument_field = lookup[node.base]
-                if node.path and not isinstance(argument_field, Field):
-                    raise EqlCompileError("Unable to expand macro {} on non-field type".format(argument_field))
+                argument_value = lookup[node.base]
+                if node.path:
+                    if not isinstance(argument_value, Field):
+                        raise EqlCompileError("Unable to expand macro {} on non-field type".format(argument_value))
 
-                # extend the attributes being retrieved
-                return Field(argument_field.base, list(argument_field.path) + list(node.path))
+                    # extend the attributes being retrieved
+                    return Field(argument_value.base, list(argument_value.path) + list(node.path))
+
+                return argument_value
 
             return node
 


### PR DESCRIPTION
## Issues
Closes https://github.com/endgameinc/eql/issues/45

## Details
Expanding attributes within macros, and now raise an error about a failed expansion instead of letting it quietly pass through as-is.

```sql
macro NAME(a)       a.name

// before: returns "a.name"
NAME(foo)   

// after: returns "foo.name"
NAME(foo)   
```