### PR TITLE
Add an optimization rule to combine matching wildcard calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.8
+_Released 2021-01-12_
+
+### Added
+* Optimization to combine adjacent `wildcard()` calls over the same field
+
+
 ## Version 0.9.7
 _Released 2020-12-01_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Version 0.9.8
-_Released 2021-01-12_
+_Released 2021-01-13_
 
 ### Added
 * Optimization to combine adjacent `wildcard()` calls over the same field

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Version 0.9.8
-_Released 2021-01-13_
+_Released 2021-01-14_
 
 ### Added
 * Optimization to combine adjacent `wildcard()` calls over the same field

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.7'
+__version__ = '0.9.8'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -492,6 +492,16 @@ class FunctionCall(Expression):
 
         return super(FunctionCall, self).render()
 
+    def __or__(self, other):
+        """Optimize OR comparisons between matching variadic binary functions."""
+        if isinstance(other, FunctionCall) and \
+                self.name in ("wildcard", "match", "matchLite") and other.name == self.name:
+            # wildcard(x, ABC...) or wildcard(x, DEF...) ==> wildcard(x, ABC..., DEF...)
+            if self.arguments[0] == other.arguments[0]:
+                return FunctionCall(self.name, self.arguments + other.arguments[1:])
+
+        return super(FunctionCall, self).__or__(other)
+
 
 class NamedSubquery(Expression):
     """Named of queries perform a subquery with a specific type and returns true if the current event is related.

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -114,8 +114,8 @@ class TestParseOptimizations(unittest.TestCase):
         optimized = parse_expression('wildcard(name, "foo*", "*bar")')
         self.assertEqual(wildcard_or, optimized, "Failed to combine OR with matching adjacent wildcard() calls")
         
-        wildcard_or = parse_expression('match(name, "fo[o]) or match(name, "ba[r]?)')
-        optimized = parse_expression('match(name, "fo[o]", "ba[r]?)")')
+        wildcard_or = parse_expression('match(name, "fo[o]") or match(name, "ba[r]?")')
+        optimized = parse_expression('match(name, "fo[o]", "ba[r]?")')
         self.assertEqual(wildcard_or, optimized, "Failed to combine OR with matching adjacent match() calls")
 
         # this isn't necessary as a test, but is worth keeping so the behavior is well defined

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -113,7 +113,7 @@ class TestParseOptimizations(unittest.TestCase):
         wildcard_or = parse_expression('name == "foo*" or name == "*bar"')
         optimized = parse_expression('wildcard(name, "foo*", "*bar")')
         self.assertEqual(wildcard_or, optimized, "Failed to combine OR with matching adjacent wildcard() calls")
-        
+
         wildcard_or = parse_expression('match(name, "fo[o]") or match(name, "ba[r]?")')
         optimized = parse_expression('match(name, "fo[o]", "ba[r]?")')
         self.assertEqual(wildcard_or, optimized, "Failed to combine OR with matching adjacent match() calls")

--- a/tests/test_optimizations.py
+++ b/tests/test_optimizations.py
@@ -113,6 +113,10 @@ class TestParseOptimizations(unittest.TestCase):
         wildcard_or = parse_expression('name == "foo*" or name == "*bar"')
         optimized = parse_expression('wildcard(name, "foo*", "*bar")')
         self.assertEqual(wildcard_or, optimized, "Failed to combine OR with matching adjacent wildcard() calls")
+        
+        wildcard_or = parse_expression('match(name, "fo[o]) or match(name, "ba[r]?)')
+        optimized = parse_expression('match(name, "fo[o]", "ba[r]?)")')
+        self.assertEqual(wildcard_or, optimized, "Failed to combine OR with matching adjacent match() calls")
 
         # this isn't necessary as a test, but is worth keeping so the behavior is well defined
         wildcard_or = parse_expression('name == "foo*" or other_field == "bar" or name == "*baz"')


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues
Closes #47 

## Details
Fairly self-explanatory. If you see `wildcard(x, "wc*1") or wildcard(x, "wc*2")` then just combine them to be `wildcard(x, "wc*1", "wc*1")`. This only works if the fields are the same, and the optimizer recognizes these two calls as adjacent. So if you have a bunch of stuff between the two calls, it won't recognize the pattern and will leave it as-is.