### PR TITLE
Fix the NodeInfo for ILike

### DIFF
--- a/eql/parser.py
+++ b/eql/parser.py
@@ -594,7 +594,7 @@ class LarkToEQL(Interpreter):
             if not child.validate_type(TypeHint.String):
                 raise self._type_error(child, TypeHint.String)
 
-        return NodeInfo(ast.FunctionCall("wildcard", [child.node for child in children], TypeHint.Boolean))
+        return NodeInfo(ast.FunctionCall("wildcard", [child.node for child in children]), TypeHint.Boolean)
 
     def comparison(self, node):
         """Callback function to walk the AST."""


### PR DESCRIPTION
## Issues
None

## Details
Noticed that pretty printed queries were rendering as a method:
```python
not process.args:wildcard("C:\\windows\\temp\\nessus_*.txt", "C:\\windows\\TEMP\\nessus_*.TMP", "C:\\Windows\\CCM\\SystemTemp\\*", "C:\\Windows\\CCMCache\\*", "C:\\CCM\\Cache\\*")] by host.id 
```

This is because of python's truthiness and the type hint wasn't assigned to NodeInfo but as actually sent to `as_method` and was truthy. Need to update the changelog. It's not urgent, so I'll just pull this into the next version