### PR TITLE
Add regex/regex~, like/like~ and func~()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Version 0.9.9
-_Released 2021-02-10_
+_Released 2021-02-22_
 
 ### Added
 * Elasticsearch `like`/ `like~` syntax

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.9
+_Released 2021-02-10_
+
+### Added
+* Elasticsearch `like`/ `like~` syntax
+* Elasticsearch `regex` / `regex~` syntax
+* Elasticsearch insensitive function syntax `function~(...)`
+
 # Version 0.9.8
 _Released 2021-01-14_
 
@@ -18,7 +26,7 @@ _Released 2020-12-01_
 _Released 2020-11-24_
 
 ### Changed
-* Elasticsearch ilike `:` syntax to support lists and wildcards
+* Elasticsearch insensitive wildcard `:` syntax to support lists and wildcards
 
 
 ## Version 0.9.5

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.8'
+__version__ = '0.9.9'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -33,15 +33,20 @@ expressions: expr ("," expr)* [","]
 ?and_expr: not_expr ("and" not_expr)*
 ?not_expr.3: NOT_OP* term
 ?term: sum_expr comp_op sum_expr -> comparison
-     | sum_expr "not" "in" "(" expressions [","]? ")"  -> not_in_set
-     | sum_expr "in" "(" expressions [","]? ")" -> in_set
-     | sum_expr ILIKE (literal | "(" literal ("," literal)* ")") -> ilike
+     | sum_expr "not" IN "(" expressions [","]? ")"  -> not_in_set
+     | sum_expr IN "(" expressions [","]? ")" -> in_set
+     | sum_expr STRING_PREDICATE (literal | "(" literal ("," literal)* ")") -> string_predicate
      | sum_expr
 
 
 // Need to recover these tokens
+IN.3: "in~" | "in"
 EQUALS: "==" | "="
-ILIKE: ":"
+STRING_PREDICATE.3:  ":"
+                  |  "like~"
+                  |  "regex~"
+                  |  "like"
+                  |  "regex"
 COMP_OP: "<=" | "<" | "!=" | ">=" | ">"
 ?comp_op: EQUALS | COMP_OP
 MULT_OP:    "*" | "/" | "%"
@@ -62,7 +67,7 @@ named_subquery.2: name "of" subquery
 METHOD_START.3: ":" NAME "("
 method_name: METHOD_START
 method: method_name [expressions] ")"
-function_call: name "(" [expressions] ")"
+function_call: (INSENSITIVE_NAME | NAME) "(" [expressions] ")"
 ?atom: single_atom
      |  "(" expr ")"
 ?signed_single_atom: SIGN? single_atom
@@ -114,6 +119,7 @@ LETTER: UCASE_LETTER | LCASE_LETTER
 WORD: LETTER+
 
 ESCAPED_NAME: "`" /[^`\r\n]+/ "`"
+INSENSITIVE_NAME.2: ("_"|LETTER) ("_"|LETTER|DIGIT)* "~"
 NAME: ("_"|LETTER) ("_"|LETTER|DIGIT)*
 UNSIGNED_INTEGER: /[0-9]+/
 EXPONENT: /[Ee][-+]?\d+/

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -485,8 +485,12 @@ class LarkToEQL(Interpreter):
 
     def name(self, node):
         """Check for illegal use of keyword."""
-        text = node["NAME"].value
-        if text in keywords:
+        if isinstance(node, KvTree):
+            text = node.children[0].value
+        else:
+            text = str(node)
+
+        if text.rstrip("~") in keywords:
             raise self._error(node, "Invalid use of keyword", cls=EqlSyntaxError)
 
         return text
@@ -583,10 +587,22 @@ class LarkToEQL(Interpreter):
         field = ast.Field(base, path)
         return self._update_field_info(NodeInfo(field, source=node))
 
-    def ilike(self, node):
+    def string_predicate(self, node):
         """Callback function to walk the AST."""
+        predicate = node["STRING_PREDICATE"]
+        if predicate == ":":
+            function_name = "wildcard"
+        elif predicate in ("like", "like~"):
+            function_name = "wildcard"
+        elif predicate in ("regex", "regex~"):
+            function_name = "match"
+        else:
+            raise self._error(node, message="Invalid syntax", cls=EqlSyntaxError)
+
         if not self._elasticsearch_syntax:
-            raise self._error(node, message="Invalid syntax, try == or wildcard()", cls=EqlSyntaxError)
+            args = ", ".join(self.text[n.meta.start_pos:n.meta.end_pos] for n in node.child_trees)
+            raise self._error(node, "Invalid syntax. Try: {function_name}({args})", cls=EqlSyntaxError,
+                              function_name=function_name, args=args)
 
         children = self.visit(node.child_trees)
 
@@ -594,7 +610,7 @@ class LarkToEQL(Interpreter):
             if not child.validate_type(TypeHint.String):
                 raise self._type_error(child, TypeHint.String)
 
-        return NodeInfo(ast.FunctionCall("wildcard", [child.node for child in children], TypeHint.Boolean))
+        return NodeInfo(ast.FunctionCall(function_name, [child.node for child in children], TypeHint.Boolean))
 
     def comparison(self, node):
         """Callback function to walk the AST."""
@@ -641,21 +657,22 @@ class LarkToEQL(Interpreter):
         eql_node = ast.Comparison(left.node, op, right.node)
 
         # there is no special comparison operator for wildcards, just look for * in the string
-        if not self._elasticsearch_syntax and isinstance(right.node, ast.String) and '*' in right.node.value:
-            func_call = ast.FunctionCall('wildcard', [left.node, right.node])
+        if not self._elasticsearch_syntax:
+            if isinstance(right.node, ast.String) and '*' in right.node.value:
+                func_call = ast.FunctionCall('wildcard', [left.node, right.node])
 
-            if op == ast.Comparison.EQ:
-                eql_node = func_call
-            elif op == ast.Comparison.NE:
-                eql_node = ~func_call
+                if op == ast.Comparison.EQ:
+                    eql_node = func_call
+                elif op == ast.Comparison.NE:
+                    eql_node = ~func_call
 
-        elif not self._elasticsearch_syntax and isinstance(left.node, ast.String) and '*' in left.node.value:
-            func_call = ast.FunctionCall('wildcard', [right.node, left.node])
+            elif isinstance(left.node, ast.String) and '*' in left.node.value:
+                func_call = ast.FunctionCall('wildcard', [right.node, left.node])
 
-            if op == ast.Comparison.EQ:
-                eql_node = func_call
-            elif op == ast.Comparison.NE:
-                eql_node = ~func_call
+                if op == ast.Comparison.EQ:
+                    eql_node = func_call
+                elif op == ast.Comparison.NE:
+                    eql_node = ~func_call
 
         return NodeInfo(eql_node, TypeHint.Boolean, nullable=left.nullable or right.nullable, source=node)
 
@@ -727,7 +744,11 @@ class LarkToEQL(Interpreter):
 
     def in_set(self, node):
         """Callback function to walk the AST."""
-        outer, container = self.visit_children(node)  # type: (NodeInfo, list[NodeInfo])
+        if not self._elasticsearch_syntax and node.get("IN") == "in~":
+            raise self._error(node, message="Invalid syntax. Explicit case-insensitivity is not supported.",
+                              cls=EqlSyntaxError)
+
+        outer, container = self.visit(node.child_trees)  # type: (NodeInfo, list[NodeInfo])
 
         if not outer.validate_type(TypeHint.primitives()):
             # can't compare non-primitives to sets
@@ -770,9 +791,23 @@ class LarkToEQL(Interpreter):
 
     def function_call(self, node, prev_node=None, prev_arg=None):
         """Callback function to walk the AST."""
-        function_name = self.visit(node["name"] or node["method_name"])
+        if node.data == "method":
+            name_node = node["method_name"]
+            function_name = self.method_name(name_node)
+        else:
+            name_node = node.children[0]
+            function_name = self.name(name_node)
+
         args = []
         nodes = []
+
+        if function_name.endswith("~"):
+            # remove the trailing ~ and use the existing AST
+            function_name = function_name.rstrip("~")
+
+            if not self._elasticsearch_syntax:
+                raise self._error(node, "Invalid syntax. Explicit case-insensitivity is not supported",
+                                  cls=EqlSyntaxError)
 
         non_method_arguments = node["expressions"].children if node["expressions"] else []
 
@@ -840,7 +875,7 @@ class LarkToEQL(Interpreter):
             return NodeInfo(expr, signature.return_value, nullable=nullable, source=node)
 
         elif self._check_functions:
-            raise self._error(node["name"], "Unknown function {NAME}")
+            raise self._error(name_node, "Unknown function {function_name}", function_name=function_name)
         else:
             args = []
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with io.open('eql/__init__.py', 'rt', encoding='utf8') as f:
     __version__ = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
 
 install_requires = [
-    "lark-parser~=0.10.1",
+    "lark-parser~=0.11.1",
     "enum34; python_version<'3.4'",
 ]
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -511,7 +511,7 @@ class TestParser(unittest.TestCase):
         simple_extracted = extract_query_terms(network_event + "| unique process_name, user_name\n\n| tail 10")
         self.assertListEqual(simple_extracted, [network_event.strip()])
 
-    def test_elasticsearch_flag_enabled(self):
+    def test_elasticsearch_flag(self):
         """Check that removed Endgame syntax throws an error and new syntax does not."""
         schema = Schema({"process": {"process_name": "string",  "pid": "number"}})
 
@@ -523,13 +523,28 @@ class TestParser(unittest.TestCase):
             parse_query('process where process_name : ("cmd*.exe", "foo*.exe")')
             parse_query('process where process_name : ("cmd*.exe", """foo*.exe""")')
 
+            parse_query('process where process_name in~ ("cmd.exe", """foo.exe""")')
+            parse_query('process where process_name in ("cmd.exe", """foo.exe""")')
+
+            parse_query('process where process_name like ("cmd*.exe", """foo*.exe""")')
+            parse_query('process where process_name like~ ("cmd*.exe", """foo*.exe""")')
+
+            parse_query('process where process_name regex ("cmd*.exe", """foo*.exe""")')
+            parse_query('process where process_name regex~ ("""cmd.*\\.exe""", """foo.*\\.exe""")')
+
+            parse_query("process where startsWith(process_name, \"cmd.exe\")")
+            parse_query("process where startsWith~(process_name, \"cmd.exe\")")
+
             # invalid syntax, because the right side should be a string literal or list of literals
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name :  length()")
 
             self.assertRaises(EqlSemanticError, parse_query, "process where pid : 1")
+            self.assertRaises(EqlSemanticError, parse_query, "process where pid like 1")
+            self.assertRaises(EqlSemanticError, parse_query, "process where pid regex 1")
+            self.assertRaises(EqlSemanticError, parse_query, "process where pid like~ 1")
+            self.assertRaises(EqlSemanticError, parse_query, "process where pid regex~ 1")
 
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name = \"cmd.exe\"")
-
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == 'cmd.exe'")
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == ?'cmd.exe'")
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == ?\"cmd.exe\"")
@@ -538,8 +553,28 @@ class TestParser(unittest.TestCase):
             parse_query("process where process_name == 'cmd.exe'")
             parse_query("process where process_name == ?'cmd.exe'")
             parse_query("process where process_name == ?\"cmd.exe\"")
+            parse_query("process where startsWith(process_name, \"cmd.exe\")")
 
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name :  length()")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name like  length()")
             self.assertRaises(EqlSyntaxError, parse_query, 'process where process_name == """cmd.exe"""')
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name : \"cmd.exe\"")
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name : (\"cmd.exe\")")
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name :  length()")
+            self.assertRaises(EqlSyntaxError, parse_query, 'process where process_name == """cmd.exe"""')
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name in~ (\"cmd.exe\")")
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name like \"cmd.exe\"")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name like (\"cmd.exe\")")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name like~ \"cmd.exe\"")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name like~ (\"cmd.exe\")")
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name regex~ (\"cmd.exe\")")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name regex \"cmd.exe\"")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name regex (\"cmd.exe\")")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name regex~ \"cmd.exe\"")
+            self.assertRaises(EqlSyntaxError, parse_query, "process where process_name regex~ (\"cmd.exe\")")
+
+            self.assertRaises(EqlSyntaxError, parse_query, "process where startsWith~(process_name, \"cmd.exe\")")


### PR DESCRIPTION
## Issues
Closes #50 

## Details
Added `regex`, `regex~`, `like`, `like~` and `function~(...)` syntax. The PythonEngine functionality remains unchanged since there are no AST-side changes.

Here are the error messages. In Elasticsearch mode:
```
Process finished with exit code 0
Error at line:1,column:31
Invalid syntax
process where process_name :  length()
                              ^^^^^^
Error at line:1,column:15
Expected string not number
process where pid : 1
              ^^^
Error at line:1,column:15
Expected string not number
process where pid like 1
              ^^^
Error at line:1,column:15
Expected string not number
process where pid regex 1
              ^^^
Error at line:1,column:15
Expected string not number
process where pid like~ 1
              ^^^
Error at line:1,column:15
Expected string not number
process where pid regex~ 1
              ^^^
Error at line:1,column:28
Invalid syntax. Compare with == instead of =
process where process_name = "cmd.exe"
                           ^
Error at line:1,column:31
Invalid string literal. Use " or """ based strings.
process where process_name == 'cmd.exe'
                              ^^^^^^^^^
Error at line:1,column:31
Invalid string literal. Use " or """ based strings.
process where process_name == ?'cmd.exe'
                              ^^^^^^^^^^
Error at line:1,column:31
Invalid string literal. Use " or """ based strings.
process where process_name == ?"cmd.exe"
                              ^^^^^^^^^^

```

In Endgame parsing mode (default)
```
Error at line:1,column:31
Invalid syntax
process where process_name :  length()
                              ^^^^^^
Error at line:1,column:34
Invalid syntax
process where process_name like  length()
                                 ^^^^^^
Error at line:1,column:31
Invalid string literal
process where process_name == """cmd.exe"""
                              ^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: wildcard(process_name, "cmd.exe")
process where process_name : "cmd.exe"
              ^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: wildcard(process_name, "cmd.exe")
process where process_name : ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:31
Invalid syntax
process where process_name :  length()
                              ^^^^^^
Error at line:1,column:31
Invalid string literal
process where process_name == """cmd.exe"""
                              ^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Explicit case-insensitivity is not supported.
process where process_name in~ ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: wildcard(process_name, "cmd.exe")
process where process_name like "cmd.exe"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: wildcard(process_name, "cmd.exe")
process where process_name like ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: wildcard(process_name, "cmd.exe")
process where process_name like~ "cmd.exe"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: wildcard(process_name, "cmd.exe")
process where process_name like~ ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: match(process_name, "cmd.exe")
process where process_name regex~ ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: match(process_name, "cmd.exe")
process where process_name regex "cmd.exe"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: match(process_name, "cmd.exe")
process where process_name regex ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: match(process_name, "cmd.exe")
process where process_name regex~ "cmd.exe"
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Try: match(process_name, "cmd.exe")
process where process_name regex~ ("cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error at line:1,column:15
Invalid syntax. Explicit case-insensitivity is not supported
process where startsWith~(process_name, "cmd.exe")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
