### PR TITLE
Explain that the language changes only affect Elasticsearch

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,9 +17,13 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    
    In the Elastic Stack:
    
-   - Most operators and functions are now case-sensitive. For example, ``process_name == "cmd.exe"`` is no longer equivalent to ``process_name == "Cmd.exe"``.
+   - Most operators are now case-sensitive. For example, ``process_name == "cmd.exe"`` is no longer equivalent to ``process_name == "Cmd.exe"``.
+   - Functions are now case-sensitive. To use the case-insensitive variant, use ``~``, such as ``endsWith~(process_name, ".exe")`.
    - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.
-   - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard. For case-sensitive wildcard matching, use the ``wildcard`` function.
+   - For case-insensitive wildcard comparisons, use the ``:`` operator. Both ``*`` and ``?`` are recognized wildcard characters. (7.11+)
+   - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard
+   - For wildcard matching, use the ``like`` keyword when case-sensitive, and ``like~`` when case-insensitive. The ``:`` operator is equivalent to ``like~`.  (7.12+)
+   - For regular expression matching, use ``regex`` or ``regex~``. (7.12+)
    - ``=`` can no longer be substituted for the ``==`` operator.
    - ``'`` strings are no longer supported. Use ``"""`` or ``"`` to represent strings.
    - ``?"`` and ``?'`` no longer indicate raw strings. Use the ``"""..."""`` syntax instead.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - Functions are now case-sensitive. To use the case-insensitive variant, use ``~``, such as ``endsWith~(process_name, ".exe")`.
    - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.
    - For case-insensitive wildcard comparisons, use the ``:`` operator. Both ``*`` and ``?`` are recognized wildcard characters. (7.11+)
-   - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard
+   - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard.
    - For wildcard matching, use the ``like`` keyword when case-sensitive, and ``like~`` when case-insensitive. The ``:`` operator is equivalent to ``like~``.  (7.12+)
    - For regular expression matching, use ``regex`` or ``regex~``. (7.12+)
    - ``=`` can no longer be substituted for the ``==`` operator.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,9 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
 
 
 .. note::
-   This documentation is about EQL for Elastic Endgame. Several syntax changes were made to `bring Event Query Language to the Elastic Stack <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html>`_:
+   This documentation is about EQL for Elastic Endgame. Several syntax changes were made in Elasticsearch to `bring Event Query Language to the Elastic Stack <https://www.elastic.co/guide/en/elasticsearch/reference/current/eql.html>`_. The existing Python EQL implementation remains unchanged, but please keep the below differences in mind when switching between the two different versions of EQL.
+   
+   In the Elastic Stack:
    
    - Most operators and functions are now case-sensitive. For example, ``process_name == "cmd.exe"`` is no longer equivalent to ``process_name == "Cmd.exe"``.
    - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.
    - For case-insensitive wildcard comparisons, use the ``:`` operator. Both ``*`` and ``?`` are recognized wildcard characters. (7.11+)
    - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard
-   - For wildcard matching, use the ``like`` keyword when case-sensitive, and ``like~`` when case-insensitive. The ``:`` operator is equivalent to ``like~`.  (7.12+)
+   - For wildcard matching, use the ``like`` keyword when case-sensitive, and ``like~`` when case-insensitive. The ``:`` operator is equivalent to ``like~``.  (7.12+)
    - For regular expression matching, use ``regex`` or ``regex~``. (7.12+)
    - ``=`` can no longer be substituted for the ``==`` operator.
    - ``'`` strings are no longer supported. Use ``"""`` or ``"`` to represent strings.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ EQL also has a preprocessor that can perform parse and translation time evaluati
    In the Elastic Stack:
    
    - Most operators are now case-sensitive. For example, ``process_name == "cmd.exe"`` is no longer equivalent to ``process_name == "Cmd.exe"``.
-   - Functions are now case-sensitive. To use the case-insensitive variant, use ``~``, such as ``endsWith~(process_name, ".exe")`.
+   - Functions are now case-sensitive. To use the case-insensitive variant, use ``~``, such as ``endsWith~(process_name, ".exe")``.
    - For case-insensitive equality comparisons, use the ``:`` operator. For example, ``process_name : "cmd.exe"`` is equivalent to ``process_name : "Cmd.exe"``.
    - For case-insensitive wildcard comparisons, use the ``:`` operator. Both ``*`` and ``?`` are recognized wildcard characters. (7.11+)
    - The ``==`` and ``!=`` operators no longer expand wildcard characters. For example, ``process_name == "cmd*.exe"`` now interprets ``*`` as a literal asterisk, not a wildcard.


### PR DESCRIPTION
## Issues
Related to #52

## Details
There was some confusion about the big "Note" text, and the way I initially wrote it was misleading and made it sound like breaking changes were made to Python EQL. However, those breaking changes were in the _language_ itself, and the best way to describe the changes is with Endgame EQL and Elasticsearch EQL.

No breaking changes were made to Endgame EQL. There is an internal flag that we use within [elastic/detection-rules](https://github.com/elastic/detection-rules) to validate against Elasticsearch EQL syntax. But this isn't documented or exposed to users, as the underlying implementation is still case-insensitive by default.

Is this language more clear, @jrodewig?

cc @cbenning.