### PR TITLE
Add support for unicode escape sequences per spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Version 0.9.11
-_Released 2021-09-23_
+_Released 2021-09-22_
 
 ### Added
 * Support for `\u{...}` [unicode escape sequences](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-escape-characters) in `"` style strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.11
+_Released 2021-09-23_
+
+### Added
+* Support for `\u{...}` [unicode escape sequences](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-escape-characters) in `"` style strings
+
 # Version 0.9.10
 _Released 2021-08-24_
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 [![Documentation](https://readthedocs.org/projects/eql/badge/?version=latest)](https://eql.readthedocs.io/en/latest/?badge=latest)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
-[![Twitter Follow](https://img.shields.io/twitter/follow/eventquerylang.svg?style=social)](https://twitter.com/eventquerylang)
-
 ![What is EQL?](docs/_static/eql-whoami.jpg)
 Browse a [library of EQL analytics](https://eqllib.readthedocs.io)
 

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = "0.9.11"
+__version__ = '0.9.11'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.10'
+__version__ = "0.9.11"
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -127,7 +127,7 @@ EXPONENT: /[Ee][-+]?\d+/
 DECIMAL: UNSIGNED_INTEGER? "." UNSIGNED_INTEGER+ EXPONENT?
        | UNSIGNED_INTEGER EXPONENT
 SIGN:           "+" | "-"
-DQ_STRING:        /"(\\[btnfr"'\\]|[^\r\n"\\])*"/
+DQ_STRING:        /"(\\[btnfr"'\\]|\\u\{[a-zA-Z0-9]{2,8}\}|[^\r\n"\\])*"/
 SQ_STRING:        /'(\\[btnfr"'\\]|[^\r\n'\\])*'/
 RAW_DQ_STRING:    /\?"(\\\"|[^"\r\n])*"/
 RAW_SQ_STRING:    /\?'(\\\'|[^'\r\n])*'/

--- a/eql/utils.py
+++ b/eql/utils.py
@@ -15,6 +15,11 @@ _loaded_plugins = False
 unicode_t = type(u"")
 long_t = type(int(1e100))
 
+try:
+    chr_compat = unichr
+except NameError:
+    chr_compat = chr
+
 if unicode_t == str:
     strings = str,
     to_unicode = str

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ test_requires = [
     "flake8-pep257==1.0.5",
     "PyYAML",
     "toml~=0.10",
+    "pluggy-1.0.0.dev0; python_version<'3.4'",
     "configparser<5.0; python_version<'3.4'",
     "contextlib2~=0.6.0",
     "more-itertools~=5.0; python_version<'3.4'",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ test_requires = [
     "flake8-pep257==1.0.5",
     "PyYAML",
     "toml~=0.10",
-    "pluggy=1.0.0.dev0; python_version<'3.4'",
+    "pluggy=1.0.0-dev0; python_version<'3.4'",
     "configparser<5.0; python_version<'3.4'",
     "contextlib2~=0.6.0",
     "more-itertools~=5.0; python_version<'3.4'",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ test_requires = [
     "flake8-pep257==1.0.5",
     "PyYAML",
     "toml~=0.10",
-    "pluggy-1.0.0.dev0; python_version<'3.4'",
+    "pluggy=1.0.0.dev0; python_version<'3.4'",
     "configparser<5.0; python_version<'3.4'",
     "contextlib2~=0.6.0",
     "more-itertools~=5.0; python_version<'3.4'",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ test_requires = [
     "flake8-pep257==1.0.5",
     "PyYAML",
     "toml~=0.10",
-    "pluggy=1.0.0-dev0; python_version<'3.4'",
+    "pluggy==1.0.0-dev0; python_version<'3.4'",
     "configparser<5.0; python_version<'3.4'",
     "contextlib2~=0.6.0",
     "more-itertools~=5.0; python_version<'3.4'",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -512,6 +512,7 @@ class TestParser(unittest.TestCase):
         self.assertListEqual(simple_extracted, [network_event.strip()])
 
     def test_unicode_escape(self):
+        """Confirm that u{...} escapes are interpreted properly."""
         self.assertEqual(String("just A here"), parse_expression('"just \\u{41} here"'))
         self.assertEqual(String("just A here"), parse_expression('"just \\u{041} here"'))
         self.assertEqual(String("just A here"), parse_expression('"just \\u{0041} here"'))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -511,6 +511,19 @@ class TestParser(unittest.TestCase):
         simple_extracted = extract_query_terms(network_event + "| unique process_name, user_name\n\n| tail 10")
         self.assertListEqual(simple_extracted, [network_event.strip()])
 
+    def test_unicode_escape(self):
+        self.assertEqual(String("just A here"), parse_expression('"just \\u{41} here"'))
+        self.assertEqual(String("just A here"), parse_expression('"just \\u{041} here"'))
+        self.assertEqual(String("just A here"), parse_expression('"just \\u{0041} here"'))
+        self.assertEqual(String("just \u0407 here"), parse_expression('"just \\u{407} here"'))
+        self.assertEqual(String("just \U0001F4A9 here"), parse_expression('"just \\u{1F4A9} here"'))
+        self.assertEqual(String("just \U0001F4A9 here"), parse_expression('"just \\u{001F4A9} here"'))
+
+        with self.assertRaises(EqlParseError):
+            parse_expression('"just \\u{0} here"')
+            parse_expression('"just \\u{1} here"')
+            parse_expression('"just \\u{0000001F4A9} here"')
+
     def test_elasticsearch_flag(self):
         """Check that removed Endgame syntax throws an error and new syntax does not."""
         schema = Schema({


### PR DESCRIPTION
## Issues
EQL escape sequences for unicode `\u{...}` weren't working as expected.

## Details
Added support for `\u{ ... }` escapes, per the [spec](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-syntax-escape-characters)