### PR TITLE
Bump requirement on lark parser to 0.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ from setuptools import setup, Command
 from setuptools.command.test import test as TestCommand
 
 
-with io.open('eql/__init__.py', 'rt', encoding='utf8') as f:
-    __version__ = re.search(r'__version__ = \'(.*?)\'', f.read()).group(1)
+with io.open("eql/__init__.py", "rt", encoding="utf8") as f:
+    __version__ = re.search(r"__version__ = \'(.*?)\'", f.read()).group(1)
 
 install_requires = [
-    "lark-parser~=0.11.1",
+    "lark-parser~=0.12.0",
     "enum34; python_version<'3.4'",
 ]
 
@@ -37,13 +37,17 @@ test_requires = [
     "importlib-metadata<3.0; python_version<'3.4'",
     "zipp<1.0; python_version<'3.4'",
 ]
-etc_files = [os.path.relpath(fn, 'eql') for fn in glob.glob('eql/etc/*') if not fn.endswith('.py')]
+etc_files = [
+    os.path.relpath(fn, "eql")
+    for fn in glob.glob("eql/etc/*")
+    if not fn.endswith(".py")
+]
 
 
 class Lint(Command):
     """Wrapper for the standard linters."""
 
-    description = 'Lint the code'
+    description = "Lint the code"
     user_options = []
 
     def initialize_options(self):
@@ -55,9 +59,10 @@ class Lint(Command):
     def run(self):
         """Run the flake8 linter."""
         self.distribution.fetch_build_eggs(test_requires)
-        self.distribution.packages.append('tests')
+        self.distribution.packages.append("tests")
 
         from flake8.main import Flake8Command
+
         flake8cmd = Flake8Command(self.distribution)
         flake8cmd.options_dict = {}
         flake8cmd.run()
@@ -83,66 +88,61 @@ class Test(TestCommand):
 
 
 setup(
-    name='eql',
+    name="eql",
     version=__version__,
-    description='Event Query Language',
+    description="Event Query Language",
     install_requires=install_requires,
-    author='Endgame, Inc.',
-    author_email='eql@endgame.com',
-    license='AGPLv3',
+    author="Endgame, Inc.",
+    author_email="eql@endgame.com",
+    license="AGPLv3",
     classifiers=[
-        'Intended Audience :: Developers',
-        'Intended Audience :: Information Technology',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: System Administrators',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Topic :: Database',
-        'Topic :: Internet :: Log Analysis',
-        'Topic :: Scientific/Engineering :: Information Analysis',
+        "Intended Audience :: Developers",
+        "Intended Audience :: Information Technology",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: System Administrators",
+        "Natural Language :: English",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Database",
+        "Topic :: Internet :: Log Analysis",
+        "Topic :: Scientific/Engineering :: Information Analysis",
     ],
-    url='https://eql.readthedocs.io',
+    url="https://eql.readthedocs.io",
     tests_require=install_requires + test_requires,
-    cmdclass={
-        'lint': Lint,
-        'test': Test
-    },
+    cmdclass={"lint": Lint, "test": Test},
     entry_points={
-        'console_scripts': [
-            'eql=eql.main:main',
+        "console_scripts": [
+            "eql=eql.main:main",
         ],
-        'pygments.lexers': [
-            'eql=eql.highlighters:EqlLexer'
-        ]
+        "pygments.lexers": ["eql=eql.highlighters:EqlLexer"],
     },
     extras_require={
-        'docs': [
-            'sphinx',
-            'sphinx_rtd_theme',
+        "docs": [
+            "sphinx",
+            "sphinx_rtd_theme",
         ],
-        'cli': [
-            'pygments',
-            'prompt_toolkit',
+        "cli": [
+            "pygments",
+            "prompt_toolkit",
         ],
-        'lint': test_requires,
-        'test': test_requires,
-        'loaders': [
-            'pyyaml',
-            'toml',
+        "lint": test_requires,
+        "test": test_requires,
+        "loaders": [
+            "pyyaml",
+            "toml",
         ],
-        'highlighters': [
-            'pygments',
-        ]
+        "highlighters": [
+            "pygments",
+        ],
     },
-    packages=['eql', 'eql.tests', 'eql.etc'],
+    packages=["eql", "eql.tests", "eql.etc"],
     package_data={
-        'eql': etc_files,
+        "eql": etc_files,
     },
     zip_safe=False,
 )


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues

Lark parser is currently using an older version that conflicts with some other packages. Bumping to latest

## Details

Specifically, I'm trying to use EQL and parsuricata in the same environment, but they currently have vastly differing version requirements on lark-parser. This addresses that and all tests still pass. 

It'd be great if we could tag a patch release if this is accepted.
