### PR TITLE
[Bug] Fix as keyword and as ecs field overlap bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.15
+
+_Released 2022-10-11_
+
+### Fixed
+
+* Bug where [as](https://www.elastic.co/guide/en/ecs/current/ecs-as.html) fields overlapped `as` keyword
+
 # Version 0.9.14
 
 _Released 2022-09-16_

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.14'
+__version__ = '0.9.15'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -59,12 +59,9 @@ elasticsearch_syntax = ParserConfig(elasticsearch_syntax=True)
 elasticsearch_validate_optional_fields = ParserConfig(elasticsearch_syntax=True, validate_optional_fields=True)
 elastic_endpoint_syntax = ParserConfig(elasticsearch_syntax=True, dollar_var=True, allow_alias=True)
 
-keywords = ("and", "as", "by", "const", "false", "in", "join", "macro",
+keywords = ("and", "by", "const", "false", "in", "join", "macro",
             "not", "null", "of", "or", "sequence", "true", "until", "with", "where"
             )
-as_keyword_exceptions = ("client.as", "destination.as", "server.as", "source.as",
-                         "threat.enrichments.indicator.as", "threat.indicator.as"
-                         )
 
 RESERVED = {n.render(): n for n in [ast.Boolean(True), ast.Boolean(False), ast.Null()]}
 
@@ -598,7 +595,7 @@ class LarkToEQL(Interpreter):
                 name = to_unicode(part["NAME"])
                 full_path.append(name)
 
-                if name in keywords and ".".join(map(str, full_path)) not in as_keyword_exceptions:
+                if name in keywords:
                     raise self._error(node, "Invalid use of keyword", cls=EqlSyntaxError)
             elif part["ESCAPED_NAME"]:
                 full_path.append(to_unicode(part["ESCAPED_NAME"]).strip("`"))

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -595,7 +595,7 @@ class LarkToEQL(Interpreter):
                 name = to_unicode(part["NAME"])
                 full_path.append(name)
 
-                if name in keywords:
+                if name in keywords or (name == "as" and self._alias_enabled):
                     raise self._error(node, "Invalid use of keyword", cls=EqlSyntaxError)
             elif part["ESCAPED_NAME"]:
                 full_path.append(to_unicode(part["ESCAPED_NAME"]).strip("`"))

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -62,6 +62,9 @@ elastic_endpoint_syntax = ParserConfig(elasticsearch_syntax=True, dollar_var=Tru
 keywords = ("and", "as", "by", "const", "false", "in", "join", "macro",
             "not", "null", "of", "or", "sequence", "true", "until", "with", "where"
             )
+as_keyword_exceptions = ("client.as", "destination.as", "server.as", "source.as",
+                         "threat.enrichments.indicator.as", "threat.indicator.as"
+                         )
 
 RESERVED = {n.render(): n for n in [ast.Boolean(True), ast.Boolean(False), ast.Null()]}
 
@@ -595,7 +598,7 @@ class LarkToEQL(Interpreter):
                 name = to_unicode(part["NAME"])
                 full_path.append(name)
 
-                if name in keywords:
+                if name in keywords and ".".join(map(str, full_path)) not in as_keyword_exceptions:
                     raise self._error(node, "Invalid use of keyword", cls=EqlSyntaxError)
             elif part["ESCAPED_NAME"]:
                 full_path.append(to_unicode(part["ESCAPED_NAME"]).strip("`"))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -688,5 +688,5 @@ class TestParser(unittest.TestCase):
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == 'cmd.exe'")
 
             # as fields not emmitted by the endpoint
-            self.assertRaises(EqlSyntaxError, parse_query, 'process where client.as.organization.name == "some string field"')
-            self.assertRaises(EqlSyntaxError, parse_query, 'process where destination.as.organization.name == "some string field"')
+            self.assertRaises(EqlSyntaxError, parse_query, 'process where client.as.organization.name == "string"')
+            self.assertRaises(EqlSyntaxError, parse_query, 'process where destination.as.organization.name == "string"')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -214,8 +214,6 @@ class TestParser(unittest.TestCase):
             'any where true | unique a b c | sort a b c | count',
             'any where true | unique a, b,   c | sort a b c | count',
             'any where true | unique a, b,   c | sort a,b,c | count',
-            'any where client.as.organization.name.text == "some string field"',
-            'any where destination.as.organization.name.text == "some string field"',
             'file where child of [registry where true]',
             'file where event of [registry where true]',
             'file where event of [registry where true]',
@@ -688,3 +686,7 @@ class TestParser(unittest.TestCase):
             self.assertRaises(EqlSchemaError, parse_query, 'sequence by user.name %s as p1 %s' % (event0, event2))
             self.assertRaises(EqlSchemaError, parse_query, 'sequence by user.name %s as p1 %s' % (event0, event3))
             self.assertRaises(EqlSyntaxError, parse_query, "process where process_name == 'cmd.exe'")
+
+            # as fields not emmitted by the endpoint
+            self.assertRaises(EqlSyntaxError, parse_query, 'process where client.as.organization.name == "some string field"')
+            self.assertRaises(EqlSyntaxError, parse_query, 'process where destination.as.organization.name == "some string field"')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -214,6 +214,8 @@ class TestParser(unittest.TestCase):
             'any where true | unique a b c | sort a b c | count',
             'any where true | unique a, b,   c | sort a b c | count',
             'any where true | unique a, b,   c | sort a,b,c | count',
+            'any where client.as.organization.name.text == "some string field"',
+            'any where destination.as.organization.name.text == "some string field"',
             'file where child of [registry where true]',
             'file where event of [registry where true]',
             'file where event of [registry where true]',


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues
Resolves #66 

## Details
- Enhanced the keyword check to account for  the `as`  keyword
- Adds test case entries for invalid `Autonomous System` [as](https://www.elastic.co/guide/en/ecs/current/ecs-as.html#_field_reuse) fields which are not emitted on the endpoint.
