### PR TITLE
Add support for array variable type validation

### DIFF
--- a/.github/workflows/pythonpackage27.yml
+++ b/.github/workflows/pythonpackage27.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a variety of Python versions
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Build 3.X
+name: Build 2.7
 
 on:
   push:
@@ -13,17 +13,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.7]
-      fail-fast: false
+    container:
+      image: python:2.7.18-buster
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.16
+
+ _Released 2023-07-27_
+
+### Added
+
+* Support for nested field validation within the arraySearch function
+
 # Version 0.9.15
 
 _Released 2022-10-11_

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.15'
+__version__ = '0.9.16'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -124,6 +124,20 @@ class ArrayContains(FunctionSignature):
                     return True
             return False
 
+    @classmethod
+    def validate(cls, arguments):  # type: (list[NodeInfo]) -> int
+        """Validate that the type of the expression matches the type of the array elements."""
+        from .schema import Schema
+
+        invalid = super(ArrayContains, cls).validate(arguments)
+        if invalid is not None:
+            return invalid
+
+        if isinstance(arguments[0].schema, list) and len(arguments[0].schema) == 1:
+            element_type, _ = Schema.convert_to_type(arguments[0].schema[0])
+            if not arguments[1].validate(element_type):
+                return 1
+
 
 @register
 class ArrayCount(DynamicFunctionSignature):

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -458,7 +458,7 @@ class LarkToEQL(Interpreter):
         if schema_hint is not None:
             type_hint, schema = schema_hint
 
-        if type_hint is None and not allow_missing and not self._in_variable:
+        if type_hint is None and not allow_missing:
             message = "Field not recognized"
             if event_type not in (EVENT_TYPE_ANY, EVENT_TYPE_GENERIC):
                 message += " for {event_type} event"

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -458,7 +458,7 @@ class LarkToEQL(Interpreter):
         if schema_hint is not None:
             type_hint, schema = schema_hint
 
-        if type_hint is None and not allow_missing:
+        if type_hint is None and not allow_missing and not self._in_variable:
             message = "Field not recognized"
             if event_type not in (EVENT_TYPE_ANY, EVENT_TYPE_GENERIC):
                 message += " for {event_type} event"

--- a/eql/types.py
+++ b/eql/types.py
@@ -62,7 +62,7 @@ class NodeInfo(object):
         :param ast.EqlNode node: The EQL node in the tree.
         :param TypeHint type_info: The type information.
         :param bool nullable: Whether the current type can be compared to null
-        :param object schema: Schema information for composite values.
+        :param object|list schema: Schema information for composite values.
         :param object source: Parse tree information for node.
         """
         self.node = node

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -731,3 +731,4 @@ class TestParser(unittest.TestCase):
 
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf1 == "three")')
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf2 == 3)')
+            parse_query('process where _arraysearch(field.nested_field, $var, $var.nf2 == 3)')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -693,7 +693,7 @@ class TestParser(unittest.TestCase):
             self.assertRaises(EqlSyntaxError, parse_query, 'process where destination.as.organization.name == "string"')
 
     def test_nested_fields(self):
-        """Test nested fields"""
+        """Test nested fields."""
         schema = Schema({
             "process": {
                 "process_name": "string",
@@ -718,14 +718,16 @@ class TestParser(unittest.TestCase):
 
         with elastic_endpoint_syntax, schema:
             # should fail since nf1 type is a string
-            self.assertRaises(EqlTypeMismatchError, parse_query, 'process where arraySearch(field.nested_field, $var, $var.nf1 == 3)')
+            self.assertRaises(EqlTypeMismatchError, parse_query,
+                              'process where arraySearch(field.nested_field, $var, $var.nf1 == 3)')
 
             # should fail since nf4 doesn't exist
-            self.assertRaises(EqlSchemaError, parse_query, 'process where arraySearch(field.nested_field, $var, $var.nf4 == "3")')
+            self.assertRaises(EqlSchemaError, parse_query,
+                              'process where arraySearch(field.nested_field, $var, $var.nf4 == "3")')
 
             # should fail since the second $ is missing
-            self.assertRaises(EqlSchemaError, parse_query, 'process where arraySearch(field.nested_field, $var, var.nf2 == 3)')
+            self.assertRaises(EqlSchemaError, parse_query,
+                              'process where arraySearch(field.nested_field, $var, var.nf2 == 3)')
 
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf1 == "three")')
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf2 == 3)')
-

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -731,4 +731,6 @@ class TestParser(unittest.TestCase):
 
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf1 == "three")')
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf2 == 3)')
+
+        with elastic_endpoint_syntax, schema, ignore_missing_functions:
             parse_query('process where _arraysearch(field.nested_field, $var, $var.nf2 == 3)')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -731,6 +731,3 @@ class TestParser(unittest.TestCase):
 
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf1 == "three")')
             parse_query('process where arraySearch(field.nested_field, $var, $var.nf2 == 3)')
-
-        with elastic_endpoint_syntax, schema, ignore_missing_functions:
-            parse_query('process where _arraysearch(field.nested_field, $var, $var.nf2 == 3)')

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,7 +2,7 @@
 import unittest
 
 from eql.events import Event
-from eql.errors import EqlSchemaError, EqlTypeMismatchError
+from eql.errors import EqlSchemaError, EqlTypeMismatchError, EqlSemanticError
 from eql.parser import parse_query, strict_booleans, non_nullable_fields, allow_enum_fields
 from eql.schema import Schema
 from eql.types import TypeHint
@@ -43,6 +43,9 @@ class TestSchemaValidation(unittest.TestCase):
                 "num": NUM
             },
             "objarray": [{}],
+            "array_array": [
+                {"s": [STR]},
+            ],
         }
     }
 
@@ -141,19 +144,27 @@ class TestSchemaValidation(unittest.TestCase):
         valid = [
             "complex where arrayContains(string_arr, 'thesearchstring')",
             "complex where arrayContains(string_arr, 'thesearchstring', 'anothersearchstring')",
-            # this should pass until generics/templates are handled better
-            "complex where arrayContains(string_arr, 1)",
-            "complex where arrayContains(string_arr, 1, 2, 3)",
             "complex where arraySearch(string_arr, x, x == '*subs*')",
-            "complex where arraySearch(objarray, x, x.key == 'k')",
-            "complex where arraySearch(objarray, x, arraySearch(x, y, y.key == true))",
             "complex where arraySearch(nested.arr, x, x == '*subs*')",
             "complex where arrayContains(objarray, 1)",
             "complex where arrayContains(objarray, 1, 2, 3)",
+            "complex where arraySearch(objarray, x, x.key == 'k')",
+            "complex where arraySearch(objarray, x, arraySearch(x, y, y.key == true))",
+            "complex where arraySearch(array_array, x, arraySearch(x.s, y, y == 'abc'))",
         ]
         with Schema(self.schema):
             for query in valid:
                 parse_query(query)
+
+    def test_array_functions_inner_type_mismatch(self):
+        valid = [
+            "complex where arrayContains(string_arr, 1)",
+            "complex where arrayContains(string_arr, 1, 2, 3)",
+            "complex where arraySearch(array_array, x, arraySearch(x.s, y, y == 1))",
+        ]
+        with Schema(self.schema):
+            for query in valid:
+                self.assertRaises(EqlSemanticError, parse_query, query)
 
     def test_array_function_failures(self):
         """Test that array functions fail on nested objects or the wrong type."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -157,6 +157,7 @@ class TestSchemaValidation(unittest.TestCase):
                 parse_query(query)
 
     def test_array_functions_inner_type_mismatch(self):
+        """Test that array functions properly perform type validation on loop expressions."""
         valid = [
             "complex where arrayContains(string_arr, 1)",
             "complex where arrayContains(string_arr, 1, 2, 3)",

--- a/tests/test_toml.py
+++ b/tests/test_toml.py
@@ -6,7 +6,7 @@ import string
 import eql
 import eql.etc
 
-from . import utils
+from tests import utils
 
 
 fold_tests = []

--- a/tests/test_type_system.py
+++ b/tests/test_type_system.py
@@ -7,7 +7,7 @@ from eql.errors import EqlTypeMismatchError
 from eql.parser import parse_expression, implied_booleans
 from eql.types import TypeFoldCheck, TypeHint, NodeInfo
 
-from . import utils
+from tests import utils
 
 
 class TestTypeSystem(unittest.TestCase):


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues
Alternative approach to #68

## Details
Basically I just updated the parser so that the behavior for loop variables implicitly is relative to an array in the directly previous argument. I don't think there are any exceptions, and if there are they can be dealt with as they occur. This approach is a bit hacky but simple enough of a change to maintain.

I started going down a rabbit hole of rewriting most of the type system, but that scope was hard to cut so I moved on to this more simplistic approach where variable behavior is implicitly defined.