### PR TITLE
[Bug] Support runs count on first query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.17
+
+ _Released 2023-08-02_
+
+### Fixed
+
+* Support for runs count field on the first subquery
+* Makefile install command
+
 # Version 0.9.16
 
  _Released 2023-07-27_

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.16'
+__version__ = '0.9.17'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -1113,11 +1113,11 @@ class LarkToEQL(Interpreter):
 
         # Figure out how many fields are joined by in the first query, and match across all
         subquery_nodes = node.get_list("subquery_by")
-        first, first_info, _ = self.subquery_by(subquery_nodes[0], allow_fork=allow_fork,
-                                                position=0, allow_runs=allow_runs)
+        first, first_info, first_runs_count = self.subquery_by(subquery_nodes[0], allow_fork=allow_fork,
+                                                               position=0, allow_runs=allow_runs)
 
         num_values = len(first_info)
-        subqueries = [(first, first_info)]
+        subqueries = [(first, first_info)] * first_runs_count
 
         shared = node['join_values']
         until_node = node["until_subquery_by"]

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -556,9 +556,6 @@ class TestParser(unittest.TestCase):
             }
         })
 
-        with elasticsearch_syntax:
-            ast = parse_query('sequence [process where process.name != null] with runs=3')
-            self.assertEqual(len(ast.first.queries), 3)
 
         with elasticsearch_syntax:
             subquery1 = '[process where opcode == 1] by unique_pid'
@@ -572,6 +569,12 @@ class TestParser(unittest.TestCase):
             self.assertRaises(EqlSemanticError, parse_query, 'sequence [process where opcode == 1] with runs=0')
             self.assertRaises(EqlSyntaxError, parse_query, 'sequence [process where opcode == 1] with runs=-1')
             self.assertRaises(EqlSemanticError, parse_query, 'sequence [process where opcode == 1] with runs=1')
+
+            # ensure runs feature is building subqueries correctly (even on first subquery)
+            ast = parse_query('sequence [process where process.name != null] with runs=3')
+            self.assertEqual(len(ast.first.queries), 3)
+            ast = parse_query('sequence [process where process.name != null]')
+            self.assertEqual(len(ast.first.queries), 1)
 
         with elasticsearch_syntax, schema:
             parse_query('process where process_name : "cmd.exe"')

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -557,6 +557,10 @@ class TestParser(unittest.TestCase):
         })
 
         with elasticsearch_syntax:
+            ast = parse_query('sequence [process where process.name != null] with runs=3')
+            self.assertEqual(len(ast.first.queries), 3)
+
+        with elasticsearch_syntax:
             subquery1 = '[process where opcode == 1] by unique_pid'
             runs = [2, 10, 30]
             for run in runs:


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues
None

## Details

The existing `runs` feature did not support sequences that use a single subquery with `runs`. This PR adds support for the first (and sometimes only) subquery that uses the `runs` feature so that the ast is properly built.


### Testing

I've added a test case that ensures the subqueries are properly built but if you want to manually test, you can parse a query and check the ast.

<details><summary>Example Testing</summary>
<p>


```
with elasticsearch_syntax:
    ast = parse_query('sequence [process where process.name != null] with runs=3')

ast.first.queries
[SubqueryBy(query=Eve...fork=None), SubqueryBy(query=Eve...fork=None), SubqueryBy(query=Eve...fork=None)]
len(ast.first.queries)
3
```

Prior to this fix, the first subquery would only show:

```
[SubqueryBy(query=Eve...fork=None)
```

</p>
</details> 

