### PR TITLE
[FR] Add support for sample base queries in elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-# Version 0.9.17
+# Version 0.9.18
 
  _Released 2023-08-20_
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Version 0.9.18
 
- _Released 2023-08-20_
+ _Released 2023-09-01_
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Version 0.9.17
 
+ _Released 2023-08-20_
+
+### Added
+
+* Support for [sample](https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-syntax.html#eql-samples) base query type for Elasticsearch queries
+
+# Version 0.9.17
+
  _Released 2023-08-02_
 
 ### Fixed

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.17'
+__version__ = '0.9.18'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -48,6 +48,7 @@ __all__ = (
     "SubqueryBy",
     "Join",
     "Sequence",
+    "Sample",
 
     # pipes
     "PipeCommand",

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -944,6 +944,33 @@ class Join(EqlNode):
         return text
 
 
+class Sample(EqlNode):
+    """Sample finds events matching the defined filters, regardless of their temporal order.
+
+    Sample supports defining one or more join keys.
+    """
+
+    __slots__ = 'queries', 'join_keys'
+
+    def __init__(self, queries, join_keys=None):
+        """Create a Sample of multiple events.
+
+        :param list[SubqueryBy] queries: List of queries to be sampled
+        :param list[str] join_keys: List of join keys
+        """
+        self.queries = queries
+        self.join_keys = join_keys or []
+
+    def _render(self):
+        text = 'sample'
+        if self.join_keys:
+            text += ' by ' + ', '.join(self.join_keys)
+        text += '\n'
+        text += self.indent('\n'.join(query.render() for query in self.queries))
+
+        return text
+
+
 class Sequence(EqlNode):
     """Sequence is very similar to join, but enforces an ordering.
 

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -950,22 +950,17 @@ class Sample(EqlNode):
     Sample supports defining one or more join keys.
     """
 
-    __slots__ = 'queries', 'join_keys'
+    __slots__ = 'queries',
 
-    def __init__(self, queries, join_keys=None):
+    def __init__(self, queries):
         """Create a Sample of multiple events.
 
         :param list[SubqueryBy] queries: List of queries to be sampled
-        :param list[str] join_keys: List of join keys
         """
         self.queries = queries
-        self.join_keys = join_keys or []
 
     def _render(self):
         text = 'sample'
-        if self.join_keys:
-            text += ' by ' + ', '.join(self.join_keys)
-        text += '\n'
         text += self.indent('\n'.join(query.render() for query in self.queries))
         return text
 

--- a/eql/ast.py
+++ b/eql/ast.py
@@ -967,7 +967,6 @@ class Sample(EqlNode):
             text += ' by ' + ', '.join(self.join_keys)
         text += '\n'
         text += self.indent('\n'.join(query.render() for query in self.queries))
-
         return text
 
 

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -938,7 +938,7 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         check_event = self.convert(subquery.query)
 
         # Determine if there's a join_value present
-        has_join_value = subquery.join_values is not None
+        has_join_value = True if subquery.join_values else False
 
         # If there's a join value, get it.
         get_join_value = self._convert_key(subquery.join_values, scoped=True) if has_join_value else None

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -973,7 +973,8 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         samples = {} if has_join_value_for_any_subquery else []
         size = len(node.queries)
 
-        for _, query in enumerate(node.queries):
+        for _, query in reversed(list(enumerate(node.queries))):
+            # Create these in reverse order, so one event can't hit multiple callbacks to be propagated
             self._convert_sample_term(query, size, samples, next_pipe)
 
     def _convert_sequence_term(self, subquery, position, size, lookups, next_pipe=None):

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -934,7 +934,7 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         for pos, query in enumerate(node.queries):
             convert_join_term(query, pos)
 
-    def _convert_sample_term(self, subquery, position, size, samples, next_pipe=None):
+    def _convert_sample_term(self, subquery, size, samples, next_pipe=None):
         check_event = self.convert(subquery.query)
         get_join_value = self._convert_key(subquery.join_values, scoped=True)
 
@@ -954,8 +954,8 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         samples = {}  # type: dict[object, list[Event]]
         size = len(node.queries)
 
-        for pos, query in enumerate(node.queries):
-            self._convert_sample_term(query, pos, size, samples, next_pipe)
+        for _, query in enumerate(node.queries):
+            self._convert_sample_term(query, size, samples, next_pipe)
 
     def _convert_sequence_term(self, subquery, position, size, lookups, next_pipe=None):
         # type: (SubqueryBy, int, int, list[dict[object, list[Event]]], callable) -> callable

--- a/eql/engine.py
+++ b/eql/engine.py
@@ -957,7 +957,6 @@ class PythonEngine(BaseEngine, BaseTranspiler):
         for pos, query in enumerate(node.queries):
             self._convert_sample_term(query, pos, size, samples, next_pipe)
 
-
     def _convert_sequence_term(self, subquery, position, size, lookups, next_pipe=None):
         # type: (SubqueryBy, int, int, list[dict[object, list[Event]]], callable) -> callable
         check_event = self.convert(subquery.query)

--- a/eql/etc/eql.g
+++ b/eql/etc/eql.g
@@ -8,10 +8,12 @@ query_with_definitions: definitions piped_query
 piped_query: base_query [pipes]
            | pipes
 base_query: sequence
+          | sample
           | join
           | event_query
 event_query: [name "where"] expr
 sequence: "sequence" [join_values with_params? | with_params join_values?] subquery_by+ [until_subquery_by]
+sample: "sample" join_values? subquery_by+
 join: "join" join_values? subquery_by subquery_by+ until_subquery_by?
 until_subquery_by.2: "until" subquery_by
 pipes: pipe+

--- a/eql/highlighters.py
+++ b/eql/highlighters.py
@@ -32,7 +32,7 @@ class EqlLexer(RegexLexer):
             include('whitespace'),
             include('comments'),
             (r'(and|in|not|or)\b', token.Operator.Word),  # Keyword.Pseudo can also work
-            (r'(join|sequence|until|where)\b', token.Keyword),
+            (r'(join|sequence|until|where|sample)\b', token.Keyword),
             (r'(%s)(=\s+)(where)\b' % _name, bygroups(token.Name, token.Whitespace, token.Keyword)),
             (r'(const)(\s+)(%s)\b' % _name, bygroups(token.Keyword.Declaration, token.Whitespace, token.Name.Constant)),
             (r'(macro)(\s+)(%s)\b' % _name, bygroups(token.Keyword.Declaration, token.Whitespace, token.Name.Constant)),

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -1221,7 +1221,7 @@ class LarkToEQL(Interpreter):
 
     def sample(self, node):
         """Callback function to walk the AST for a sample."""
-        if not self._allow_sample and not self._elasticsearch_syntax:
+        if not self._allow_sample or not self._elasticsearch_syntax:
             raise self._error(node, "Sample not supported")
 
         join_keys = []

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -1003,8 +1003,8 @@ class LarkToEQL(Interpreter):
         self._in_pipes = True
         if isinstance(first, ast.EventQuery):
             base_event_types = [first.event_type]
-        elif isinstance(first, list):
-            base_event_types = [first[0][0].node.base]
+        elif isinstance(first, ast.Sample):
+            base_event_types = [q.query.event_type for q in first.queries[0]]
         else:
             base_event_types = [q.query.event_type for q in first.queries]
 
@@ -1229,7 +1229,7 @@ class LarkToEQL(Interpreter):
         join_keys = []
 
         if node['join_values']:
-            join_keys = [self.identifier(value) for value in node['join_values']['expressions']]
+            join_keys = [key.node.base for key in self.join_values(node["join_values"])]
 
         queries = self._get_subqueries_and_close(node, allow_fork=True)
         if len(queries) <= 1 and not self._elasticsearch_syntax:

--- a/eql/parser.py
+++ b/eql/parser.py
@@ -1224,16 +1224,11 @@ class LarkToEQL(Interpreter):
         if not self._allow_sample or not self._elasticsearch_syntax:
             raise self._error(node, "Sample not supported")
 
-        join_keys = []
-
-        if node['join_values']:
-            join_keys = [key.node.base for key in self.join_values(node["join_values"])]
-
         queries, _ = self._get_subqueries_and_close(node, allow_fork=True)
         if len(queries) <= 1:
             raise self._error(node, "Only one item in the sample",
                               cls=EqlSemanticError)
-        return ast.Sample(queries, join_keys)
+        return ast.Sample(queries)
 
     def sequence(self, node):
         """Callback function to walk the AST."""

--- a/eql/utils.py
+++ b/eql/utils.py
@@ -277,6 +277,8 @@ def get_query_type(query):
 
     if isinstance(query.first, ast.Sequence):
         return "sequence"
+    elif isinstance(query.first, ast.Sample):
+        return "sample"
     elif isinstance(query.first, ast.Join):
         return "join"
     elif isinstance(query.first, ast.EventQuery):

--- a/eql/walkers.py
+++ b/eql/walkers.py
@@ -88,6 +88,13 @@ class Walker(object):
         self.base_event_types = []
         if isinstance(node.first, EventQuery):
             self.base_event_types.append(node.first.event_type)
+        elif isinstance(node.first, list):
+            # add the first node
+            self.base_event_types.append(node.first[0][0].node.base)
+
+            # iterate over a list of tuples to get the event types
+            for q in node.first[1:]:
+                self.base_event_types.append(q[0].node.query.event_type)
         else:
             self.base_event_types.extend(q.query.event_type for q in node.first.queries)
 

--- a/eql/walkers.py
+++ b/eql/walkers.py
@@ -88,8 +88,6 @@ class Walker(object):
         self.base_event_types = []
         if isinstance(node.first, EventQuery):
             self.base_event_types.append(node.first.event_type)
-        elif isinstance(node.first, Sample):
-           self.base_event_types.extend(q.query.event_type for q in node.first.queries[0])
         else:
             self.base_event_types.extend(q.query.event_type for q in node.first.queries)
 
@@ -272,4 +270,4 @@ class ConfigurableWalker(RecursiveWalker):
 
 
 # circular dependency
-from .ast import BaseNode, EventQuery, Sample  # noqa: E402
+from .ast import BaseNode, EventQuery  # noqa: E402

--- a/eql/walkers.py
+++ b/eql/walkers.py
@@ -88,13 +88,8 @@ class Walker(object):
         self.base_event_types = []
         if isinstance(node.first, EventQuery):
             self.base_event_types.append(node.first.event_type)
-        elif isinstance(node.first, list):
-            # add the first node
-            self.base_event_types.append(node.first[0][0].node.base)
-
-            # iterate over a list of tuples to get the event types
-            for q in node.first[1:]:
-                self.base_event_types.append(q[0].node.query.event_type)
+        elif isinstance(node.first, Sample):
+           self.base_event_types.extend(q.query.event_type for q in node.first.queries[0])
         else:
             self.base_event_types.extend(q.query.event_type for q in node.first.queries)
 
@@ -277,4 +272,4 @@ class ConfigurableWalker(RecursiveWalker):
 
 
 # circular dependency
-from .ast import BaseNode, EventQuery  # noqa: E402
+from .ast import BaseNode, EventQuery, Sample  # noqa: E402

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,8 +10,9 @@ from eql import Schema
 from eql.ast import *  # noqa: F403
 from eql.errors import EqlSchemaError, EqlSyntaxError, EqlSemanticError, EqlTypeMismatchError, EqlParseError
 from eql.parser import (
-    parse_query, parse_expression, parse_definitions, ignore_missing_functions, parse_field, parse_literal,
-    extract_query_terms, keywords, elasticsearch_syntax, elastic_endpoint_syntax, elasticsearch_validate_optional_fields
+    allow_sample, parse_query, parse_expression, parse_definitions, ignore_missing_functions, parse_field,
+    parse_literal, extract_query_terms, keywords, elasticsearch_syntax, elastic_endpoint_syntax,
+    elasticsearch_validate_optional_fields
 )
 from eql.walkers import DepthFirstWalker
 from eql.pipes import *   # noqa: F403
@@ -628,6 +629,14 @@ class TestParser(unittest.TestCase):
                 # optional fields in the schema
                 parse_query('process where ?process.name : "cmd.exe"')
                 parse_query('process where ?process_name : "cmd.exe"')
+
+            # sample base query usage
+            with allow_sample:
+                parse_query('sample by user [process where opcode == 1] [process where opcode == 1]')
+
+            # invalid sample base query usage
+            self.assertRaises(EqlSemanticError, parse_query,
+                              'sample by user [process where opcode == 1] [process where opcode == 1]')
 
         with schema:
             parse_query("process where process_name == 'cmd.exe'")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -10,7 +10,7 @@ from eql import Schema
 from eql.ast import *  # noqa: F403
 from eql.errors import EqlSchemaError, EqlSyntaxError, EqlSemanticError, EqlTypeMismatchError, EqlParseError
 from eql.parser import (
-    allow_sample, parse_query, parse_expression, parse_definitions, ignore_missing_functions, parse_field,
+    allow_sample, allow_runs, parse_query, parse_expression, parse_definitions, ignore_missing_functions, parse_field,
     parse_literal, extract_query_terms, keywords, elasticsearch_syntax, elastic_endpoint_syntax,
     elasticsearch_validate_optional_fields
 )
@@ -557,7 +557,7 @@ class TestParser(unittest.TestCase):
             }
         })
 
-        with elasticsearch_syntax:
+        with elasticsearch_syntax, allow_runs:
             subquery1 = '[process where opcode == 1] by unique_pid'
             runs = [2, 10, 30]
             for run in runs:


### PR DESCRIPTION
<!--    Please read the Contribution Guidelines for more information about contributing    -->
## Issues
Resolves https://github.com/endgameinc/eql/issues/70

## Details
- Adds support for sample base query types for Elasticsearch when `allow_sample` config is specified. 
- Exposes allow_runs to ensure the feature isn't used before it was introduced

## Testing

Created a sample query and stream against a list of events. Tested with and without joins. Expect to return `AnalyticOutput` hits.