### PR TITLE
[FR] Add IPv6 Support to CidrMatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Event Query Language - Changelog
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Version 0.9.19
+
+ _Released 2023-10-10_
+
+### Added
+
+* Added IPv6 support for CidrMatch
+
 # Version 0.9.18
 
  _Released 2023-09-01_

--- a/eql/__init__.py
+++ b/eql/__init__.py
@@ -66,7 +66,7 @@ from .walkers import (
     Walker,
 )
 
-__version__ = '0.9.18'
+__version__ = '0.9.19'
 __all__ = (
     "__version__",
     "AnalyticOutput",

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -225,7 +225,7 @@ class CidrMatch(FunctionSignature):
             socket.inet_pton(socket.AF_INET6, address)
             # Check if the prefix length is a valid integer between 0 and 128
             size = int(size)
-            if 0 < size <= 128:
+            if 0 <= size <= 128:
                 raise ValueError("Invalid prefix length")
             # The CIDR range is valid
             return True

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -279,20 +279,19 @@ class CidrMatch(FunctionSignature):
 
     @classmethod
     def to_mask(cls, cidr_string):
-        """Split an IP address plus cidr block to the mask."""
+        """Split an IPv4 address plus cidr block to the mask."""
         ip_string, size = cidr_string.split("/")
         size = int(size)
         ip_bytes = socket.inet_aton(ip_string)
         subnet_int, = struct.unpack(">L", ip_bytes)
 
-        mask = cls.masks[size]
+        mask = cls.masks4[size]
 
         return subnet_int & mask, mask
 
-
     @classmethod
     def to_mask_ipv6(cls, cidr_string):
-        """Split an IP address plus cidr block to the mask."""
+        """Split an IPv6 address plus cidr block to the mask."""
         ip_string, size = cidr_string.split("/")
         size = int(size)
         ip_string = cls.expand_ipv6_address(ip_string)

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -335,7 +335,9 @@ class CidrMatch(FunctionSignature):
             max_ip_integer = ip_integer | (MAX_IPV6 ^ mask)
 
             # Convert the subnet integer to a tuple of 8 16-bit integers
-            subnet_ints = struct.unpack(">8H", struct.pack(">QQ", (ip_integer >> 64), (ip_integer & 0xFFFFFFFFFFFFFFFF)))
+            subnet_ints = struct.unpack(
+                ">8H", struct.pack(">QQ", (ip_integer >> 64), (ip_integer & 0xFFFFFFFFFFFFFFFF))
+            )
             # Convert the mask to a tuple of 8 16-bit integers
             mask_ints = struct.unpack(">8H", struct.pack(">QQ", (mask >> 64), (mask & 0xFFFFFFFFFFFFFFFF)))
             # Apply the mask to the subnet integer to get the network address
@@ -436,7 +438,9 @@ class CidrMatch(FunctionSignature):
             if cls.cidrv4_compiled.match(argument.node.value):
                 subnet_bytes = struct.pack(">L", subnet_integer)
                 subnet_base = socket.inet_ntoa(subnet_bytes)
-            elif cls.cidrv6_compiled.match(argument.node.value) or cls.cidrv6_shorthand_compiled.match(argument.node.value):
+            elif cls.cidrv6_compiled.match(argument.node.value) or cls.cidrv6_shorthand_compiled.match(
+                argument.node.value
+            ):
                 subnet_bytes = struct.pack(">QQ", subnet_integer >> 64, subnet_integer & 0xFFFFFFFFFFFFFFFF)
                 subnet_base = socket.inet_ntop(socket.AF_INET6, subnet_bytes)
 

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -220,12 +220,12 @@ class CidrMatch(FunctionSignature):
         """Check if a string is a valid IPv6 CIDR range."""
         try:
             # Split the CIDR range into the address and prefix length
-            address, prefix_length = cidr.split("/")
+            address, size = cidr.split("/")
             # Check if the address is a valid IPv6 address
             socket.inet_pton(socket.AF_INET6, address)
             # Check if the prefix length is a valid integer between 0 and 128
-            prefix_length = int(prefix_length)
-            if 0 < prefix_length <= 128:
+            size = int(size)
+            if 0 < size <= 128:
                 raise ValueError("Invalid prefix length")
             # The CIDR range is valid
             return True
@@ -238,11 +238,11 @@ class CidrMatch(FunctionSignature):
         """Expand a shorthand IPv6 address or CIDR range to full notation."""
         if "/" in cidr:
             # Split the CIDR range into the address and prefix length
-            address, prefix_length = cidr.split("/")
+            address, size = cidr.split("/")
             # Expand the address
             address = cls.expand_ipv6_address(address)
             # Construct the full notation CIDR range
-            full_cidr = "{}/{}".format(address, prefix_length)
+            full_cidr = "{}/{}".format(address, size)
         else:
             # Expand the address
             full_cidr = cls.expand_ipv6_address(cidr)

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -225,7 +225,7 @@ class CidrMatch(FunctionSignature):
             socket.inet_pton(socket.AF_INET6, address)
             # Check if the prefix length is a valid integer between 0 and 128
             prefix_length = int(prefix_length)
-            if prefix_length < 0 or prefix_length > 128:
+            if 0 < prefix_length <= 128:
                 raise ValueError("Invalid prefix length")
             # The CIDR range is valid
             return True

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -356,9 +356,9 @@ class CidrMatch(FunctionSignature):
         ipv4_masks = []
         ipv6_masks = []
         for cidr in cidr_matches:
-            if cls.ipv4_compiled.match(cidr.value):
+            if cls.cidrv4_compiled.match(cidr.value):
                 ipv4_masks.append(cls.to_mask(cidr.value))
-            elif cls.ipv6_compiled.match(cidr.value) or cls.ipv6_shorthand_compiled.match(cidr.value):
+            elif cls.cidrv4_compiled.match(cidr.value) or cls.cidrv6_shorthand_compiled.match(cidr.value):
                 ipv6_masks.append(cls.to_mask(cidr.value))
 
         def callback(source, *_):
@@ -382,7 +382,6 @@ class CidrMatch(FunctionSignature):
 
         return callback
 
-    # TODO maybe only need to run expansions here
     @classmethod
     def run(cls, ip_address, *cidr_matches):
         """Compare an IP address against a list of cidr blocks."""
@@ -437,7 +436,7 @@ class CidrMatch(FunctionSignature):
             if cls.cidrv4_compiled.match(argument.node.value):
                 subnet_bytes = struct.pack(">L", subnet_integer)
                 subnet_base = socket.inet_ntoa(subnet_bytes)
-            elif cls.cidrv6_compiled.match(argument.node.value):
+            elif cls.cidrv6_compiled.match(argument.node.value) or cls.cidrv6_shorthand_compiled.match(argument.node.value):
                 subnet_bytes = struct.pack(">QQ", subnet_integer >> 64, subnet_integer & 0xFFFFFFFFFFFFFFFF)
                 subnet_base = socket.inet_ntop(socket.AF_INET6, subnet_bytes)
 

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -201,7 +201,7 @@ class CidrMatch(FunctionSignature):
 
     # store it in native representation, then recover it in network order
     masks = [struct.unpack(">L", struct.pack(">L", MAX_IP & ~(MAX_IP >> b)))[0] for b in range(33)]
-    mask_addresses4 = [socket.inet_ntoa(struct.pack(">L", m)) for m in masks]
+    mask_addresses = [socket.inet_ntoa(struct.pack(">L", m)) for m in masks]
 
     # IPv6 masks
     masks6 = [int("1" * i + "0" * (128 - i), 2) for i in range(129)]
@@ -279,7 +279,7 @@ class CidrMatch(FunctionSignature):
 
     @classmethod
     def to_mask(cls, cidr_string):
-        """Split an IPv4 address plus cidr block to the mask."""
+        """Split an IPv4 or IPv6 address plus cidr block to the mask."""
         ip_string, size = cidr_string.split("/")
         size = int(size)
         if cls.ip_compiled.match(ip_string):

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -225,7 +225,7 @@ class CidrMatch(FunctionSignature):
             socket.inet_pton(socket.AF_INET6, address)
             # Check if the prefix length is a valid integer between 0 and 128
             size = int(size)
-            if 0 <= size <= 128:
+            if 0 >= size <= 128:
                 raise ValueError("Invalid prefix length")
             # The CIDR range is valid
             return True

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -210,6 +210,7 @@ class CidrMatch(FunctionSignature):
 
     @classmethod
     def check_ipv6(cls, n):
+        """Check if a string is a valid IPv6 address."""
         try:
             socket.inet_pton(socket.AF_INET6, n)
             return True
@@ -218,6 +219,7 @@ class CidrMatch(FunctionSignature):
 
     @classmethod
     def check_ipv6_cidr(cls, cidr):
+        """Check if a string is a valid IPv6 CIDR range."""
         try:
             # Split the CIDR range into the address and prefix length
             address, prefix_length = cidr.split("/")
@@ -326,7 +328,6 @@ class CidrMatch(FunctionSignature):
     @classmethod
     def make_hex_re(cls, start, end):
         """Create a regex pattern for a range of hexadecimal values."""
-
         def generate_hex_range_pattern(min_value, max_value):
             """Generate a regex pattern for a range of hexadecimal values."""
             pattern = ""
@@ -439,7 +440,7 @@ class CidrMatch(FunctionSignature):
                 for cidr in cidr_matches:
                     if is_string(cidr) and (cls.check_ipv6_cidr(cidr)):
                         cidr = cls.expand_ipv6(cidr)
-                        subnet, mask = cls.to_mask(cidr)
+                        subnet, mask = cls.to_mask_ipv6(cidr)
                         if ip_integer & mask == subnet:
                             return True
 

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -202,6 +202,8 @@ class CidrMatch(FunctionSignature):
     masks = [struct.unpack(">L", struct.pack(">L", MAX_IP & ~(MAX_IP >> b)))[0] for b in range(33)]
     mask_addresses = [socket.inet_ntoa(struct.pack(">L", m)) for m in masks]
 
+    # TODO add support for IPv6
+
     @classmethod
     def to_mask(cls, cidr_string):
         """Split an IP address plus cidr block to the mask."""

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -298,11 +298,12 @@ class CidrMatch(FunctionSignature):
         size = int(size)
         ip_string = cls.expand_ipv6_address(ip_string)
         ip_bytes = socket.inet_pton(socket.AF_INET6, ip_string)
+        high, low = struct.unpack('>QQ', ip_bytes)
+        address_int = (high << 64) | low
 
-        # modify to return int with mask applied, and mask
-        address_int = int.from_bytes(ip_bytes, byteorder="big")
+        mask = cls.masks6[size]
 
-        return address_int & cls.masks6[size], cls.masks6[size]
+        return address_int & mask, mask
 
     @classmethod
     def make_octet_re(cls, start, end):

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -12,6 +12,7 @@ from .utils import is_string, to_unicode, is_number, fold_case, is_insensitive
 _registry = {}
 REGEX_FLAGS = re.UNICODE | re.DOTALL
 MAX_IP = 0xffffffff
+MAX_IPV6 = 0xffffffffffffffffffffffffffffffff
 
 
 def regex_flags():
@@ -340,7 +341,7 @@ class CidrMatch(FunctionSignature):
             ip_bytes = socket.inet_pton(socket.AF_INET6, ip_string)
             ip_integer = int.from_bytes(ip_bytes, byteorder="big")
             mask = cls.masks6[prefix_len]
-            max_ip_integer = ip_integer | (MAX_IP6 ^ mask)
+            max_ip_integer = ip_integer | (MAX_IPV6 ^ mask)
             min_h16s = struct.unpack(">8H", struct.pack(">QQ", ip_integer >> 64, ip_integer & 0xFFFFFFFFFFFFFFFF))
             max_h16s = struct.unpack(
                 ">8H", struct.pack(">QQ", max_ip_integer >> 64, max_ip_integer & 0xFFFFFFFFFFFFFFFF)
@@ -365,9 +366,9 @@ class CidrMatch(FunctionSignature):
 
         def callback(source, *_):
             if is_string(source) and (
-                cls.ipv4_compiled.match(source)
-                or cls.ipv6_compiled.match(source)
-                or cls.ipv6_shorthand_compiled.match(source)
+                cls.ipv4_compiled.match(source) or
+                cls.ipv6_compiled.match(source) or
+                cls.ipv6_shorthand_compiled.match(source)
             ):
                 if cls.ipv4_compiled.match(source):
                     ip_integer, _ = cls.to_mask(source + "/32")
@@ -389,9 +390,9 @@ class CidrMatch(FunctionSignature):
     def run(cls, ip_address, *cidr_matches):
         """Compare an IP address against a list of cidr blocks."""
         if is_string(ip_address) and (
-            cls.ipv4_compiled.match(ip_address)
-            or cls.ipv6_compiled.match(ip_address)
-            or cls.ipv6_shorthand_compiled.match(ip_address)
+            cls.ipv4_compiled.match(ip_address) or
+            cls.ipv6_compiled.match(ip_address) or
+            cls.ipv6_shorthand_compiled.match(ip_address)
         ):
             if cls.ipv4_compiled.match(ip_address):
                 ip_integer, _ = cls.to_mask(ip_address + "/32")

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -225,7 +225,7 @@ class CidrMatch(FunctionSignature):
             socket.inet_pton(socket.AF_INET6, address)
             # Check if the prefix length is a valid integer between 0 and 128
             size = int(size)
-            if 0 >= size <= 128:
+            if 0 < size > 128:
                 raise ValueError("Invalid prefix length")
             # The CIDR range is valid
             return True

--- a/eql/functions.py
+++ b/eql/functions.py
@@ -260,8 +260,9 @@ class CidrMatch(FunctionSignature):
             right_groups = right.split(":")
             num_left_groups = len(left_groups)
             num_right_groups = len(right_groups)
+            max_groups = 8
             # Calculate the number of groups in the middle part
-            num_middle_groups = 8 - num_left_groups - num_right_groups
+            num_middle_groups = max_groups - num_left_groups - num_right_groups
             # Construct the full notation address
             middle_groups = ["0000"] * num_middle_groups
             full_groups = left_groups + middle_groups + right_groups

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -289,9 +289,6 @@ class TestFunctions(unittest.TestCase):
 
     def test_ipv6_cidr_regex(self):
         """Test that octet regex are correctly matching the range."""
-
-        test = CidrMatch.make_cidr_regex("7ccd:f50:96ad:b6c1:1855:ddb7:6fa7:471/126")
-        # Test address e7b:d8c7:ae35:ee5e:626f:eb5a:cb2:8273
         for _ in range(200):
             # make an ip address
             ip_addr = tuple(random.randrange(65536) for _ in range(8))


### PR DESCRIPTION
## Issues
Relates https://github.com/elastic/ia-trade-team/issues/196

## Alternative PR

This PR is an alternative version of https://github.com/endgameinc/eql/pull/80

## Details

This PR adds support for IPv6 to the `cidrMatch` function, for more context see the related issues. 

### IPv4 vs IPv6

This PR attempts to follow the same logical flow for the IPv4 version of `cidrMatch`. However, there are a few required changes worth noting to support some IPv6 specific features.

#### Compressed notation
- IPv6 supports compressed notation where trailing zeroes can be truncated to `::` and leading zeros can be dropped. 
    - Example: `2001:0db8:0000:0000:0000:0000:0000:0001` is the same as `2001:db8::1` 
- The generated regex patterns in the current implementation support addresses in either notation style.
- When the python engine comparisons are made, the compressed notation addresses are expanded in order to be able to appropriately determine if the address is in the cidr range. 

####  Increased address space 
   - IPv4 uses 32 bit addresses where IPv6 uses 128 bit addresses. 
   - In Python3 there are a number of different ways to convert these addresses into numeric values (or similar objects) for bitwise/masking comparison
   - In Python2 however, the reliable, native method for doing this is by using the `struct.unpack` function which unpacks the byte string (original string input from they query) into an integer. 
       
       For IPv4 one can use the following unpack the string into a single integer value
       ```python
        ip_bytes = socket.inet_aton(ip_string)
        (subnet_int,) = struct.unpack(">L", ip_bytes)
       ```
       
       For IPv6 since the address space is 128 bit instead of 32, we are unpacking the string into two unsigned long integers instead and recombining them into a single integer (after expanding IPv6 string in case it is in compressed notation). 
       ```python
        ip_string = cls.expand_ipv6_address(ip_string)
        ip_bytes = socket.inet_pton(socket.AF_INET6, ip_string)
        high, low = struct.unpack('>QQ', ip_bytes)
        address_int = (high << 64) | low
       ```

#### IPv4 Code

For existing IPv4 code this PR attempts to edit this code as little as possible. There are cases where significant readability improvements could be made by editing the code. If desired, happy to make these updated in this PR. 

For instance the following update to `make_octet_re`

<details><summary>Updated "make_octet_re"</summary>
<p>

```python

    @classmethod
    def make_octet_re(cls, start, end):
        """Convert an octet-range into a regular expression."""
        combos = []

        if start == 0 and end == 255:
            return cls.octet_re

        # IPv4 octet range
        if start >= 0 and start < 255 and end <= 255:
            for o in range(start, end + 1):
                combos.append("{:d}".format(o))
        # IPv6 h16 range
        elif start >= 0 and end <= 65535:
            for h16 in range(start, end + 1):
                combos.append("{:d}".format(h16))
        else:
            raise ValueError("Invalid octet range")

        return "(?:{})".format("|".join(combos))
```

</p>
</details> 

## Testing

The majority of the testing can be performed via the new `ipv6` labeled unit tests in `test_python_engine.py` and `test_functions.py`. However, additional testing can be performed by calling the functions directly from a python script. 

<details><summary>Example Python Script</summary>
<p>

```python
from eql.functions import CidrMatch

# create a list of CIDR blocks to match against
cidr_blocks = ["192.168.0.0/24", "2001:db8::/32"]

# create an instance of the CidrMatch class
cidr_matcher = CidrMatch()


# call the run method with an IP address and the list of CIDR blocks
ip_address = "192.168.0.1"
result = cidr_matcher.run(ip_address, *cidr_blocks)

# print the result
print(result)  # True


# create a list of CIDR blocks to match against
cidr_blocks = ["2001:0db8:0000:0000:0000:0000:0000:0000/32", "fe80::/10"]

# create an instance of the CidrMatch class
cidr_matcher = CidrMatch()

# call the run method with an IPv6 address and the list of CIDR blocks
ipv6_address = "2001:0db8:0000:0000:0000:0000:0000:0001"
ipv6_address = "2001:db8::1"
ipv6_address = "fe80::1"
print(ipv6_address)
result = cidr_matcher.run(ipv6_address, *cidr_blocks)
print(result)

ipv6_address = CidrMatch.expand_ipv6_address(ipv6_address)
print(ipv6_address)
result = cidr_matcher.run(ipv6_address, *cidr_blocks)

# print the result
print(result)  # True

```

</p>
</details> 

:red_circle: **Important** :red_circle: 

The testing MUST be performed on both Python 3.7 and Python 2.7 as eql needs to be able to support both. Some editors such VSCode do not support debugging in Python 2.7 so one will have to run the unit tests via another method. 